### PR TITLE
ci: perform CI AWS stack cleanup after failure

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,7 @@ jobs:
               run: |
                   cdk destroy --force geospatial-data-lake
               working-directory: infra
+              if: always()  # clean-up AWS stack after failure
 
 
     deploy:


### PR DESCRIPTION
This fixes problem when after CI failure AWS stack was not deleted and all subsequent CI jobs started to fail due duplicate AWS stack resources.