### PR TITLE
ci: replace deprecated 'set-env' command with environment file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,7 +124,7 @@ jobs:
             - name: Set unique deployment environment type variable
               run: |
                   DEPLOY_ENV=ci$(date +%s)
-                  echo ::set-env name=DEPLOY_ENV::"$DEPLOY_ENV"
+                  echo "DEPLOY_ENV=$DEPLOY_ENV" | tee -a $GITHUB_ENV
 
             - name: Deploy AWS stack for testing
               run: |


### PR DESCRIPTION
see: https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/

closes: #57