### PR TITLE
ci: Wait for stack teardown before deploying

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,9 @@ jobs:
                   python -m pip install poetry
                   python -m poetry install --extras='cdk datasets-endpoint'
 
+            - name: Install AWS CLI
+              run: sudo apt install awscli
+
             - name: Use Node.js 12.x for CDK deployment
               uses: actions/setup-node@v2.1.2
               with:
@@ -120,6 +123,12 @@ jobs:
               run: |
                   DEPLOY_ENV=ci
                   echo "DEPLOY_ENV=$DEPLOY_ENV" | tee -a $GITHUB_ENV
+
+            - name: Wait for teardown of existing stacks
+              run: |
+                  timeout 2h \
+                      ./.github/workflows/wait-for-stack-teardown.bash \
+                      geospatial-data-lake-ci geospatial-data-lake-processing-ci
 
             - name: Deploy AWS stacks for testing
               run: |

--- a/.github/workflows/wait-for-stack-teardown.bash
+++ b/.github/workflows/wait-for-stack-teardown.bash
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+set -o errexit -o nounset
+
+for stack_name
+do
+    while true
+    do
+        stack_info="$(aws cloudformation describe-stacks --query "Stacks[?contains(@.StackName,'${stack_name}')].[StackName]" --output text)"
+        if [[ -z "$stack_info" ]]
+        then
+            break
+        fi
+
+        echo "Waiting for ${stack_name} teardown…" >&2
+        sleep 3
+    done
+done
+
+echo "All stacks are gone"


### PR DESCRIPTION
This should allow us to run multiple CI pipelines in parallel.