### PR TITLE
feat(infra): allow usage of existing VPC coming with AWS account

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -136,6 +136,8 @@ jobs:
               run: |
                   poetry run cdk bootstrap aws://unknown-account/ap-southeast-2
                   poetry run cdk deploy --all --require-approval never
+              env:
+                  DATALAKE_USE_EXISTING_VPC: true
 
             - name: Run tests
               run: >
@@ -218,11 +220,12 @@ jobs:
               if: >
                   github.ref == 'refs/heads/master'
                   && github.repository == 'linz/geospatial-data-lake'
-              env:
-                  DEPLOY_ENV: nonprod
               run: |
                   poetry run cdk bootstrap aws://unknown-account/ap-southeast-2
                   poetry run cdk deploy --all --require-approval never
+              env:
+                  DEPLOY_ENV: nonprod
+                  DATALAKE_USE_EXISTING_VPC: true
 
             # PROD DEPLOYMENT
             - name: (Prod) Configure AWS credentials
@@ -241,8 +244,9 @@ jobs:
               if: >
                   startsWith(github.ref, 'release')
                   && github.repository == 'linz/geospatial-data-lake'
-              env:
-                  DEPLOY_ENV: prod
               run: |
                   poetry run cdk bootstrap aws://unknown-account/ap-southeast-2
                   poetry run cdk deploy --all --require-approval never
+              env:
+                  DEPLOY_ENV: prod
+                  DATALAKE_USE_EXISTING_VPC: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,9 +144,7 @@ jobs:
 
             - name: Destroy AWS stacks used for testing
               run: |
-                  # Don't drop networking stack. It is updated very rarely and deployment/destroy
-                  # takes a very long time.
-                  poetry run cdk destroy --force storage processing api
+                  poetry run cdk destroy --force networking storage processing api
               if: always()  # clean-up AWS stack after failure
 
 

--- a/README.md
+++ b/README.md
@@ -93,10 +93,16 @@ Re-run `. .venv/bin/activate` in each shell.
     ```bash
     aws-azure-login --profile=<AWS-PROFILE-NAME>
     ```
+1. Environment variables
+* **DEPLOY_ENV:** set deployment environment. Recommended values: prod, nonprod, ci, dev or any
+    string without spaces. Default: dev.
+* **DATALAKE_USE_EXISTING_VPC:** determine if networking stack will use existing VPC in target AWS
+    account or will create a new one. Existing VPC must to be used must contain following tags -
+    "ApplicationName": "geospatial-data-lake", "ApplicationLayer": "networking".
+    Allowed values: true, false. Default: false.
 1. Deploy CDK stack
 
     ```bash
-    export DEPLOY_ENV=dev # Or 'ci', 'prod'
     cdk --profile=<AWS-PROFILE-NAME> bootstrap aws://unknown-account/ap-southeast-2
     cdk --profile=<AWS-PROFILE-NAME> deploy --all
     ```

--- a/app.py
+++ b/app.py
@@ -23,6 +23,7 @@ networking = NetworkingStack(
     "networking",
     stack_name=f"geospatial-data-lake-networking-{ENV}",
     env={"region": os.environ["CDK_DEFAULT_REGION"], "account": os.environ["CDK_DEFAULT_ACCOUNT"]},
+    deploy_env=ENV,
 )
 
 storage = StorageStack(

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ networking = NetworkingStack(
     stack_name=f"geospatial-data-lake-networking-{ENV}",
     env={"region": os.environ["CDK_DEFAULT_REGION"], "account": os.environ["CDK_DEFAULT_ACCOUNT"]},
     deploy_env=ENV,
+    use_existing_vpc=True,  # use already existing VPC, pre-configured in AWS account
 )
 
 storage = StorageStack(

--- a/app.py
+++ b/app.py
@@ -16,6 +16,14 @@ from datalake.storage_stack import StorageStack
 ENV = os.environ.get("DEPLOY_ENV", "dev")
 
 
+def str2bool(value: str) -> bool:
+    if value.upper() == "TRUE":
+        return True
+    if value.upper() == "FALSE":
+        return False
+    raise ValueError(f"Not a valid boolean: '{value}'")
+
+
 app = core.App()
 
 networking = NetworkingStack(
@@ -24,7 +32,7 @@ networking = NetworkingStack(
     stack_name=f"geospatial-data-lake-networking-{ENV}",
     env={"region": os.environ["CDK_DEFAULT_REGION"], "account": os.environ["CDK_DEFAULT_ACCOUNT"]},
     deploy_env=ENV,
-    use_existing_vpc=True,  # use already existing VPC, pre-configured in AWS account
+    use_existing_vpc=str2bool(os.environ.get("DATALAKE_USE_EXISTING_VPC", "false")),
 )
 
 storage = StorageStack(

--- a/datalake/networking_stack.py
+++ b/datalake/networking_stack.py
@@ -8,7 +8,7 @@ from aws_cdk.core import Tags
 class NetworkingStack(core.Stack):
     """Data Lake networking stack definition."""
 
-    def __init__(self, scope: core.Construct, stack_id: str, **kwargs) -> None:
+    def __init__(self, scope: core.Construct, stack_id: str, deploy_env, **kwargs) -> None:
         super().__init__(scope, stack_id, **kwargs)
 
         ############################################################################################
@@ -32,5 +32,6 @@ class NetworkingStack(core.Stack):
                     reserved=True,
                 ),
             ],
+            max_azs=99 if deploy_env == "prod" else 1,
         )
         Tags.of(self.datalake_vpc).add("ApplicationLayer", "networking")

--- a/datalake/networking_stack.py
+++ b/datalake/networking_stack.py
@@ -8,30 +8,45 @@ from aws_cdk.core import Tags
 class NetworkingStack(core.Stack):
     """Data Lake networking stack definition."""
 
-    def __init__(self, scope: core.Construct, stack_id: str, deploy_env, **kwargs) -> None:
+    def __init__(
+        self, scope: core.Construct, stack_id: str, deploy_env, use_existing_vpc, **kwargs
+    ) -> None:
         super().__init__(scope, stack_id, **kwargs)
 
         ############################################################################################
         # ### NETWORKING ###########################################################################
         ############################################################################################
 
-        self.datalake_vpc = aws_ec2.Vpc(
-            self,
-            "datalake",
-            # cidr='10.0.0.0/16',  # TODO: use speciffic CIDR
-            subnet_configuration=[
-                aws_ec2.SubnetConfiguration(
-                    cidr_mask=27, name="public", subnet_type=aws_ec2.SubnetType.PUBLIC
-                ),
-                aws_ec2.SubnetConfiguration(
-                    cidr_mask=20, name="ecs-cluster", subnet_type=aws_ec2.SubnetType.PRIVATE
-                ),
-                aws_ec2.SubnetConfiguration(
-                    name="reserved",
-                    subnet_type=aws_ec2.SubnetType.PRIVATE,
-                    reserved=True,
-                ),
-            ],
-            max_azs=99 if deploy_env == "prod" else 1,
-        )
-        Tags.of(self.datalake_vpc).add("ApplicationLayer", "networking")
+        if use_existing_vpc:
+            # use existing VPC
+            self.datalake_vpc = aws_ec2.Vpc.from_lookup(
+                self,
+                "datalake-vpc",
+                tags={
+                    "ApplicationName": "geospatial-data-lake",
+                    "ApplicationLayer": "networking",
+                },
+            )
+
+        else:
+            # create new VPC
+            self.datalake_vpc = aws_ec2.Vpc(
+                self,
+                "datalake",
+                # cidr='10.0.0.0/16',  # TODO: use specific CIDR
+                subnet_configuration=[
+                    aws_ec2.SubnetConfiguration(
+                        cidr_mask=27, name="public", subnet_type=aws_ec2.SubnetType.PUBLIC
+                    ),
+                    aws_ec2.SubnetConfiguration(
+                        cidr_mask=20, name="ecs-cluster", subnet_type=aws_ec2.SubnetType.PRIVATE
+                    ),
+                    aws_ec2.SubnetConfiguration(
+                        name="reserved",
+                        subnet_type=aws_ec2.SubnetType.PRIVATE,
+                        reserved=True,
+                    ),
+                ],
+                max_azs=99 if deploy_env == "prod" else 1,
+            )
+            Tags.of(self.datalake_vpc).add("ApplicationLayer", "networking")

--- a/datalake/processing_stack.py
+++ b/datalake/processing_stack.py
@@ -137,7 +137,6 @@ class ProcessingStack(core.Stack):
             "compute-environment",
             compute_resources=aws_batch.ComputeResources(
                 vpc=vpc,
-                # vpc_subnets=vpc.select_subnets(subnet_group_name="ecs-cluster"),  # TODO
                 minv_cpus=0,
                 desiredv_cpus=0,
                 maxv_cpus=1000,


### PR DESCRIPTION
This change is introducing following features:

* possibility to use existing VPC provided by/coming with AWS account
* or in case we create VPC by our networking stack, it is created with limited networking resources (NAT GW, EIPs) if deployment environment is not `prod`. This will reduce cost of networking resources for test and CI deployments and will
reduce usage of EIPs (which is limited to 5 EIPs/AWS account).

Closes: #134