### PR TITLE
fix(infra): run 'check_stac_metadata' test first in dataset validation

### DIFF
--- a/datalake/processing_stack.py
+++ b/datalake/processing_stack.py
@@ -282,9 +282,9 @@ class ProcessingStack(core.Stack):
         # STATE MACHINE
         # state machine definition
         dataset_version_creation_definition = (
-            step_tasks["check_flat_directory_structure"]
+            step_tasks["check_stac_metadata"]
+            .next(step_tasks["check_flat_directory_structure"])
             .next(step_tasks["content_iterator"])
-            .next(step_tasks["check_stac_metadata"])
             .next(step_tasks["check_files_checksums"])
             .next(
                 aws_stepfunctions.Choice(self, "content_iteration_finished")


### PR DESCRIPTION
`check_stac_metadata` step should run as first one.