### PR TITLE
fix: Make boto3 a production dependency

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1001,8 +1001,8 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 name = "boto3"
 version = "1.16.37"
 description = "The AWS SDK for Python"
-category = "dev"
-optional = false
+category = "main"
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -1015,7 +1015,7 @@ name = "botocore"
 version = "1.19.37"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -1155,7 +1155,7 @@ name = "jmespath"
 version = "0.10.0"
 description = "JSON Matching Expressions"
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
@@ -1457,7 +1457,7 @@ name = "s3transfer"
 version = "0.3.3"
 description = "An Amazon S3 Transfer Manager"
 category = "main"
-optional = false
+optional = true
 python-versions = "*"
 
 [package.dependencies]
@@ -1524,7 +1524,7 @@ name = "urllib3"
 version = "1.26.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
-optional = false
+optional = true
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
 
 [package.extras]
@@ -1595,13 +1595,13 @@ pyyaml = "*"
 
 [extras]
 cdk = ["aws-cdk.aws-dynamodb", "aws-cdk.aws-ec2", "aws-cdk.aws-ecr", "aws-cdk.aws-ecr_assets", "aws-cdk.aws-ecs", "aws-cdk.aws-iam", "aws-cdk.aws-lambda", "aws-cdk.aws-s3", "aws-cdk.aws-stepfunctions", "aws-cdk.aws-stepfunctions_tasks", "awscli", "cattrs"]
-check-stac-metadata-job = ["jsonschema", "strict-rfc3339"]
+check-stac-metadata-job = ["boto3", "jsonschema", "strict-rfc3339"]
 datasets-endpoint = ["jsonschema", "pynamodb"]
 
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.9"
-content-hash = "0488998e378a4ad5cc2eba4175f90836ddc353fe6c74920aa7378dc9f8a7498d"
+content-hash = "c0921d263e026a5047cb6de9b922088b174ef1d5444ee77372616de884daa7e7"
 
 [metadata.files]
 appdirs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ python = "^3.8,<3.9"
 "aws-cdk.aws-stepfunctions" = {version="*", optional=true}
 "aws-cdk.aws-stepfunctions_tasks" = {version="*", optional=true}
 awscli = {version="*", optional=true}
+boto3 = {version="*", optional=true}
 cattrs = {version="*", optional=true}
 jsonschema = {version="*", extras = ["format"], optional=true}
 pynamodb = {version="*", optional=true}
@@ -43,7 +44,6 @@ strict-rfc3339 = {version = "*", optional = true}
 
 [tool.poetry.dev-dependencies]
 black = "*"
-boto3 = "*"
 gitlint = "*"
 isort = "*"
 pre-commit = "*"


### PR DESCRIPTION
Follow-up to https://github.com/linz/geospatial-data-lake/pull/154, since the original code was installing the development packages.