### PR TITLE
fix: Upgrade AWS CDK package

### DIFF
--- a/datalake/constructs/batch_job_queue.py
+++ b/datalake/constructs/batch_job_queue.py
@@ -72,6 +72,7 @@ class BatchJobQueue(core.Construct):
             launch_template_name=f"{deploy_env}-datalake-batch-launch-template",
             launch_template_data=launch_template_data,
         )
+        assert cloudformation_launch_template.launch_template_name is not None
         launch_template = aws_batch.LaunchTemplateSpecification(
             launch_template_name=cloudformation_launch_template.launch_template_name
         )

--- a/datalake/constructs/lambda_task.py
+++ b/datalake/constructs/lambda_task.py
@@ -1,6 +1,7 @@
 from typing import Callable, Iterable, Optional
 
-from aws_cdk import aws_lambda, aws_stepfunctions_tasks, core
+from aws_cdk import aws_stepfunctions_tasks, core
+from aws_cdk.aws_iam import Grant, IGrantable
 
 from .bundled_lambda_function import BundledLambdaFunction
 
@@ -13,7 +14,7 @@ class LambdaTask(core.Construct):
         *,
         directory: str,
         result_path: str,
-        permission_functions: Optional[Iterable[Callable[[aws_lambda.Function], None]]] = None,
+        permission_functions: Optional[Iterable[Callable[[IGrantable], Grant]]] = None,
         application_layer: str,
     ):
         super().__init__(scope, construct_id)

--- a/datalake/processing_stack.py
+++ b/datalake/processing_stack.py
@@ -89,6 +89,7 @@ class ProcessingStack(core.Stack):
             application_layer=application_layer,
         ).lambda_invoke
 
+        array_size = int(aws_stepfunctions.JsonPath.number_at("$.content.iteration_size"))
         check_files_checksums_task = BatchSubmitJobTask(
             self,
             "check_files_checksums_task",
@@ -104,7 +105,7 @@ class ProcessingStack(core.Stack):
                 "first_item.$": "$.content.first_item",
             },
             container_overrides_environment={"BATCH_JOB_FIRST_ITEM_INDEX": "Ref::first_item"},
-            array_size=aws_stepfunctions.JsonPath.number_at("$.content.iteration_size"),
+            array_size=array_size,
             container_overrides_command=["--metadata-url", "Ref::metadata_url"],
         ).batch_submit_job
 
@@ -140,7 +141,7 @@ class ProcessingStack(core.Stack):
                     content_iterator_task,
                 )
                 .otherwise(
-                    validation_summary_task.next(
+                    validation_summary_task.next(  # type: ignore[arg-type]
                         aws_stepfunctions.Choice(self, "validation_successful")
                         .when(
                             aws_stepfunctions.Condition.boolean_equals(
@@ -157,7 +158,7 @@ class ProcessingStack(core.Stack):
         state_machine = aws_stepfunctions.StateMachine(
             self,
             f"{deploy_env}-dataset-version-creation",
-            definition=dataset_version_creation_definition,
+            definition=dataset_version_creation_definition,  # type: ignore[arg-type]
         )
 
         aws_ssm.StringParameter(

--- a/poetry.lock
+++ b/poetry.lock
@@ -62,888 +62,936 @@ tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>
 
 [[package]]
 name = "aws-cdk.assets"
-version = "1.71.0"
+version = "1.89.0"
 description = "This module is deprecated. All types are now available under the core module"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-apigateway"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ApiGateway"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.71.0"
-"aws-cdk.aws-certificatemanager" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.aws-s3-assets" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.aws-certificatemanager" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-cognito" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-s3-assets" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
+publication = ">=0.0.3"
+
+[[package]]
+name = "aws-cdk.aws-apigatewayv2"
+version = "1.89.0"
+description = "The CDK Construct Library for AWS::APIGatewayv2"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+"aws-cdk.aws-certificatemanager" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+constructs = ">=3.2.0,<4.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-applicationautoscaling"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ApplicationAutoScaling"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-autoscaling-common" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::AutoScaling"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling-common" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-autoscaling-common" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancing" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling-common"
-version = "1.71.0"
+version = "1.89.0"
 description = "Common implementation package for @aws-cdk/aws-autoscaling and @aws-cdk/aws-applicationautoscaling"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-autoscaling-hooktargets"
-version = "1.71.0"
+version = "1.89.0"
 description = "Lifecycle hook for AWS AutoScaling"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-autoscaling" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.aws-sns-subscriptions" = "1.71.0"
-"aws-cdk.aws-sqs" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-autoscaling" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.aws-sns-subscriptions" = "1.89.0"
+"aws-cdk.aws-sqs" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-batch"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::Batch"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-ecr" = "1.71.0"
-"aws-cdk.aws-ecs" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-ecr" = "1.89.0"
+"aws-cdk.aws-ecs" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-secretsmanager" = "1.89.0"
+"aws-cdk.aws-ssm" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-certificatemanager"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CertificateManager"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-route53" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-route53" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudformation"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CloudFormation"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudfront"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CloudFront"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-certificatemanager" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-ssm" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cloudwatch"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CloudWatch"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codebuild"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CodeBuild"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-codecommit" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-ecr" = "1.71.0"
-"aws-cdk.aws-ecr-assets" = "1.71.0"
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.aws-s3-assets" = "1.71.0"
-"aws-cdk.aws-secretsmanager" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.region-info" = "1.71.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-codecommit" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-ecr" = "1.89.0"
+"aws-cdk.aws-ecr-assets" = "1.89.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-s3-assets" = "1.89.0"
+"aws-cdk.aws-secretsmanager" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.region-info" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codecommit"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CodeCommit"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-codeguruprofiler"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::CodeGuruProfiler"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-cognito"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::Cognito"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.custom-resources" = "1.71.0"
+"aws-cdk.aws-certificatemanager" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.custom-resources" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
+publication = ">=0.0.3"
+
+[[package]]
+name = "aws-cdk.aws-databrew"
+version = "1.89.0"
+description = "The CDK Construct Library for AWS::DataBrew"
+category = "main"
+optional = true
+python-versions = ">=3.6"
+
+[package.dependencies]
+"aws-cdk.core" = "1.89.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-dynamodb"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::DynamoDB"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.custom-resources" = "1.71.0"
+"aws-cdk.aws-applicationautoscaling" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.custom-resources" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ec2"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::EC2"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.aws-s3-assets" = "1.71.0"
-"aws-cdk.aws-ssm" = "1.71.0"
-"aws-cdk.cloud-assembly-schema" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
-"aws-cdk.region-info" = "1.71.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-s3-assets" = "1.89.0"
+"aws-cdk.aws-ssm" = "1.89.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
+"aws-cdk.region-info" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ECR"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.custom-resources" = "1.71.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecr-assets"
-version = "1.71.0"
+version = "1.89.0"
 description = "Docker image assets deployed to ECR"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.71.0"
-"aws-cdk.aws-ecr" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.assets" = "1.89.0"
+"aws-cdk.aws-ecr" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ecs"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ECS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.71.0"
-"aws-cdk.aws-autoscaling" = "1.71.0"
-"aws-cdk.aws-autoscaling-hooktargets" = "1.71.0"
-"aws-cdk.aws-certificatemanager" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-ecr" = "1.71.0"
-"aws-cdk.aws-ecr-assets" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.aws-route53" = "1.71.0"
-"aws-cdk.aws-route53-targets" = "1.71.0"
-"aws-cdk.aws-secretsmanager" = "1.71.0"
-"aws-cdk.aws-servicediscovery" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.aws-sqs" = "1.71.0"
-"aws-cdk.aws-ssm" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.aws-applicationautoscaling" = "1.89.0"
+"aws-cdk.aws-autoscaling" = "1.89.0"
+"aws-cdk.aws-autoscaling-hooktargets" = "1.89.0"
+"aws-cdk.aws-certificatemanager" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-ecr" = "1.89.0"
+"aws-cdk.aws-ecr-assets" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancing" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.aws-route53" = "1.89.0"
+"aws-cdk.aws-route53-targets" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-s3-assets" = "1.89.0"
+"aws-cdk.aws-secretsmanager" = "1.89.0"
+"aws-cdk.aws-servicediscovery" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.aws-sqs" = "1.89.0"
+"aws-cdk.aws-ssm" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-efs"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::EFS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.cloud-assembly-schema" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-elasticloadbalancing"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ElasticLoadBalancing"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-elasticloadbalancingv2"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ElasticLoadBalancingV2"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-certificatemanager" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.region-info" = "1.71.0"
+"aws-cdk.aws-certificatemanager" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
+"aws-cdk.region-info" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-events"
-version = "1.71.0"
+version = "1.89.0"
 description = "Amazon EventBridge Construct Library"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-glue"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::Glue"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-iam"
-version = "1.71.0"
+version = "1.89.0"
 description = "CDK routines for easily assigning correct and minimal IAM permissions"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.region-info" = "1.71.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.region-info" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-kms"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::KMS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-lambda"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::Lambda"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-applicationautoscaling" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-codeguruprofiler" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-efs" = "1.71.0"
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.aws-s3-assets" = "1.71.0"
-"aws-cdk.aws-sqs" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.aws-applicationautoscaling" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-codeguruprofiler" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-ecr" = "1.89.0"
+"aws-cdk.aws-ecr-assets" = "1.89.0"
+"aws-cdk.aws-efs" = "1.89.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-s3-assets" = "1.89.0"
+"aws-cdk.aws-sqs" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-logs"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::Logs"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-s3-assets" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-s3-assets" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-route53"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::Route53"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.cloud-assembly-schema" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.custom-resources" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-route53-targets"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS Route53 Alias Targets"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-apigateway" = "1.71.0"
-"aws-cdk.aws-cloudfront" = "1.71.0"
-"aws-cdk.aws-cognito" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancing" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-route53" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.region-info" = "1.71.0"
+"aws-cdk.aws-apigateway" = "1.89.0"
+"aws-cdk.aws-apigatewayv2" = "1.89.0"
+"aws-cdk.aws-cloudfront" = "1.89.0"
+"aws-cdk.aws-cognito" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancing" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-route53" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.region-info" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::S3"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-s3-assets"
-version = "1.71.0"
+version = "1.89.0"
 description = "Deploy local files and directories to S3"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
+"aws-cdk.assets" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sam"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for the AWS Serverless Application Model (SAM) resources"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-secretsmanager"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::SecretsManager"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-sam" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-sam" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-servicediscovery"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::ServiceDiscovery"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-elasticloadbalancingv2" = "1.71.0"
-"aws-cdk.aws-route53" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-elasticloadbalancingv2" = "1.89.0"
+"aws-cdk.aws-route53" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sns"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::SNS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-sqs" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-sqs" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sns-subscriptions"
-version = "1.71.0"
+version = "1.89.0"
 description = "CDK Subscription Constructs for AWS SNS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.aws-sqs" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.aws-sqs" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-sqs"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::SQS"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-ssm"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::SSM"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.cloud-assembly-schema" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-stepfunctions"
-version = "1.71.0"
+version = "1.89.0"
 description = "The CDK Construct Library for AWS::StepFunctions"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-events" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-events" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.aws-stepfunctions-tasks"
-version = "1.71.0"
+version = "1.89.0"
 description = "Task integrations for AWS StepFunctions"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.assets" = "1.71.0"
-"aws-cdk.aws-batch" = "1.71.0"
-"aws-cdk.aws-cloudwatch" = "1.71.0"
-"aws-cdk.aws-codebuild" = "1.71.0"
-"aws-cdk.aws-dynamodb" = "1.71.0"
-"aws-cdk.aws-ec2" = "1.71.0"
-"aws-cdk.aws-ecr" = "1.71.0"
-"aws-cdk.aws-ecr-assets" = "1.71.0"
-"aws-cdk.aws-ecs" = "1.71.0"
-"aws-cdk.aws-glue" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-kms" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-s3" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.aws-sqs" = "1.71.0"
-"aws-cdk.aws-stepfunctions" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-batch" = "1.89.0"
+"aws-cdk.aws-cloudwatch" = "1.89.0"
+"aws-cdk.aws-codebuild" = "1.89.0"
+"aws-cdk.aws-databrew" = "1.89.0"
+"aws-cdk.aws-dynamodb" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-ecr" = "1.89.0"
+"aws-cdk.aws-ecr-assets" = "1.89.0"
+"aws-cdk.aws-ecs" = "1.89.0"
+"aws-cdk.aws-glue" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-kms" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-s3" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.aws-sqs" = "1.89.0"
+"aws-cdk.aws-stepfunctions" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cloud-assembly-schema"
-version = "1.71.0"
+version = "1.89.0"
 description = "Cloud Assembly Schema"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.core"
-version = "1.71.0"
+version = "1.89.0"
 description = "AWS Cloud Development Kit Core Library"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.71.0"
-"aws-cdk.cx-api" = "1.71.0"
-"aws-cdk.region-info" = "1.71.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+"aws-cdk.cx-api" = "1.89.0"
+"aws-cdk.region-info" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.custom-resources"
-version = "1.71.0"
+version = "1.89.0"
 description = "Constructs for implementing CDK custom resources"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.aws-cloudformation" = "1.71.0"
-"aws-cdk.aws-iam" = "1.71.0"
-"aws-cdk.aws-lambda" = "1.71.0"
-"aws-cdk.aws-logs" = "1.71.0"
-"aws-cdk.aws-sns" = "1.71.0"
-"aws-cdk.core" = "1.71.0"
+"aws-cdk.aws-cloudformation" = "1.89.0"
+"aws-cdk.aws-ec2" = "1.89.0"
+"aws-cdk.aws-iam" = "1.89.0"
+"aws-cdk.aws-lambda" = "1.89.0"
+"aws-cdk.aws-logs" = "1.89.0"
+"aws-cdk.aws-sns" = "1.89.0"
+"aws-cdk.core" = "1.89.0"
 constructs = ">=3.2.0,<4.0.0"
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.cx-api"
-version = "1.71.0"
+version = "1.89.0"
 description = "Cloud executable protocol"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-"aws-cdk.cloud-assembly-schema" = "1.71.0"
-jsii = ">=1.14.0,<2.0.0"
+"aws-cdk.cloud-assembly-schema" = "1.89.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "aws-cdk.region-info"
-version = "1.71.0"
+version = "1.89.0"
 description = "AWS region information, such as service principal names"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.15.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
 name = "awscli"
-version = "1.19.5"
+version = "1.19.6"
 description = "Universal Command Line Environment for AWS."
 category = "main"
 optional = true
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
-botocore = "1.20.5"
+botocore = "1.20.6"
 colorama = ">=0.2.5,<0.4.4"
 docutils = ">=0.10,<0.16"
 PyYAML = ">=3.10,<5.4"
@@ -982,298 +1030,298 @@ d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "boto3"
-version = "1.17.5"
+version = "1.17.6"
 description = "The AWS SDK for Python"
 category = "main"
 optional = true
 python-versions = ">= 2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*"
 
 [package.dependencies]
-botocore = ">=1.20.5,<1.21.0"
+botocore = ">=1.20.6,<1.21.0"
 jmespath = ">=0.7.1,<1.0.0"
 s3transfer = ">=0.3.0,<0.4.0"
 
 [[package]]
 name = "boto3-stubs"
-version = "1.17.5.0"
-description = "Type annotations for boto3 1.17.5, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3 1.17.6, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-mypy-boto3-batch = {version = "1.17.5.0", optional = true, markers = "extra == \"batch\""}
-mypy-boto3-dynamodb = {version = "1.17.5.0", optional = true, markers = "extra == \"dynamodb\""}
-mypy-boto3-lambda = {version = "1.17.5.0", optional = true, markers = "extra == \"lambda\""}
-mypy-boto3-s3 = {version = "1.17.5.0", optional = true, markers = "extra == \"s3\""}
-mypy-boto3-ssm = {version = "1.17.5.0", optional = true, markers = "extra == \"ssm\""}
-mypy-boto3-stepfunctions = {version = "1.17.5.0", optional = true, markers = "extra == \"stepfunctions\""}
+mypy-boto3-batch = {version = "1.17.6.0", optional = true, markers = "extra == \"batch\""}
+mypy-boto3-dynamodb = {version = "1.17.6.0", optional = true, markers = "extra == \"dynamodb\""}
+mypy-boto3-lambda = {version = "1.17.6.0", optional = true, markers = "extra == \"lambda\""}
+mypy-boto3-s3 = {version = "1.17.6.0", optional = true, markers = "extra == \"s3\""}
+mypy-boto3-ssm = {version = "1.17.6.0", optional = true, markers = "extra == \"ssm\""}
+mypy-boto3-stepfunctions = {version = "1.17.6.0", optional = true, markers = "extra == \"stepfunctions\""}
 
 [package.extras]
-accessanalyzer = ["mypy-boto3-accessanalyzer (==1.17.5.0)"]
-acm = ["mypy-boto3-acm (==1.17.5.0)"]
-acm-pca = ["mypy-boto3-acm-pca (==1.17.5.0)"]
-alexaforbusiness = ["mypy-boto3-alexaforbusiness (==1.17.5.0)"]
-all = ["mypy-boto3-accessanalyzer (==1.17.5.0)", "mypy-boto3-acm (==1.17.5.0)", "mypy-boto3-acm-pca (==1.17.5.0)", "mypy-boto3-alexaforbusiness (==1.17.5.0)", "mypy-boto3-amp (==1.17.5.0)", "mypy-boto3-amplify (==1.17.5.0)", "mypy-boto3-amplifybackend (==1.17.5.0)", "mypy-boto3-apigateway (==1.17.5.0)", "mypy-boto3-apigatewaymanagementapi (==1.17.5.0)", "mypy-boto3-apigatewayv2 (==1.17.5.0)", "mypy-boto3-appconfig (==1.17.5.0)", "mypy-boto3-appflow (==1.17.5.0)", "mypy-boto3-appintegrations (==1.17.5.0)", "mypy-boto3-application-autoscaling (==1.17.5.0)", "mypy-boto3-application-insights (==1.17.5.0)", "mypy-boto3-appmesh (==1.17.5.0)", "mypy-boto3-appstream (==1.17.5.0)", "mypy-boto3-appsync (==1.17.5.0)", "mypy-boto3-athena (==1.17.5.0)", "mypy-boto3-auditmanager (==1.17.5.0)", "mypy-boto3-autoscaling (==1.17.5.0)", "mypy-boto3-autoscaling-plans (==1.17.5.0)", "mypy-boto3-backup (==1.17.5.0)", "mypy-boto3-batch (==1.17.5.0)", "mypy-boto3-braket (==1.17.5.0)", "mypy-boto3-budgets (==1.17.5.0)", "mypy-boto3-ce (==1.17.5.0)", "mypy-boto3-chime (==1.17.5.0)", "mypy-boto3-cloud9 (==1.17.5.0)", "mypy-boto3-clouddirectory (==1.17.5.0)", "mypy-boto3-cloudformation (==1.17.5.0)", "mypy-boto3-cloudfront (==1.17.5.0)", "mypy-boto3-cloudhsm (==1.17.5.0)", "mypy-boto3-cloudhsmv2 (==1.17.5.0)", "mypy-boto3-cloudsearch (==1.17.5.0)", "mypy-boto3-cloudsearchdomain (==1.17.5.0)", "mypy-boto3-cloudtrail (==1.17.5.0)", "mypy-boto3-cloudwatch (==1.17.5.0)", "mypy-boto3-codeartifact (==1.17.5.0)", "mypy-boto3-codebuild (==1.17.5.0)", "mypy-boto3-codecommit (==1.17.5.0)", "mypy-boto3-codedeploy (==1.17.5.0)", "mypy-boto3-codeguru-reviewer (==1.17.5.0)", "mypy-boto3-codeguruprofiler (==1.17.5.0)", "mypy-boto3-codepipeline (==1.17.5.0)", "mypy-boto3-codestar (==1.17.5.0)", "mypy-boto3-codestar-connections (==1.17.5.0)", "mypy-boto3-codestar-notifications (==1.17.5.0)", "mypy-boto3-cognito-identity (==1.17.5.0)", "mypy-boto3-cognito-idp (==1.17.5.0)", "mypy-boto3-cognito-sync (==1.17.5.0)", "mypy-boto3-comprehend (==1.17.5.0)", "mypy-boto3-comprehendmedical (==1.17.5.0)", "mypy-boto3-compute-optimizer (==1.17.5.0)", "mypy-boto3-config (==1.17.5.0)", "mypy-boto3-connect (==1.17.5.0)", "mypy-boto3-connect-contact-lens (==1.17.5.0)", "mypy-boto3-connectparticipant (==1.17.5.0)", "mypy-boto3-cur (==1.17.5.0)", "mypy-boto3-customer-profiles (==1.17.5.0)", "mypy-boto3-databrew (==1.17.5.0)", "mypy-boto3-dataexchange (==1.17.5.0)", "mypy-boto3-datapipeline (==1.17.5.0)", "mypy-boto3-datasync (==1.17.5.0)", "mypy-boto3-dax (==1.17.5.0)", "mypy-boto3-detective (==1.17.5.0)", "mypy-boto3-devicefarm (==1.17.5.0)", "mypy-boto3-devops-guru (==1.17.5.0)", "mypy-boto3-directconnect (==1.17.5.0)", "mypy-boto3-discovery (==1.17.5.0)", "mypy-boto3-dlm (==1.17.5.0)", "mypy-boto3-dms (==1.17.5.0)", "mypy-boto3-docdb (==1.17.5.0)", "mypy-boto3-ds (==1.17.5.0)", "mypy-boto3-dynamodb (==1.17.5.0)", "mypy-boto3-dynamodbstreams (==1.17.5.0)", "mypy-boto3-ebs (==1.17.5.0)", "mypy-boto3-ec2 (==1.17.5.0)", "mypy-boto3-ec2-instance-connect (==1.17.5.0)", "mypy-boto3-ecr (==1.17.5.0)", "mypy-boto3-ecr-public (==1.17.5.0)", "mypy-boto3-ecs (==1.17.5.0)", "mypy-boto3-efs (==1.17.5.0)", "mypy-boto3-eks (==1.17.5.0)", "mypy-boto3-elastic-inference (==1.17.5.0)", "mypy-boto3-elasticache (==1.17.5.0)", "mypy-boto3-elasticbeanstalk (==1.17.5.0)", "mypy-boto3-elastictranscoder (==1.17.5.0)", "mypy-boto3-elb (==1.17.5.0)", "mypy-boto3-elbv2 (==1.17.5.0)", "mypy-boto3-emr (==1.17.5.0)", "mypy-boto3-emr-containers (==1.17.5.0)", "mypy-boto3-es (==1.17.5.0)", "mypy-boto3-events (==1.17.5.0)", "mypy-boto3-firehose (==1.17.5.0)", "mypy-boto3-fms (==1.17.5.0)", "mypy-boto3-forecast (==1.17.5.0)", "mypy-boto3-forecastquery (==1.17.5.0)", "mypy-boto3-frauddetector (==1.17.5.0)", "mypy-boto3-fsx (==1.17.5.0)", "mypy-boto3-gamelift (==1.17.5.0)", "mypy-boto3-glacier (==1.17.5.0)", "mypy-boto3-globalaccelerator (==1.17.5.0)", "mypy-boto3-glue (==1.17.5.0)", "mypy-boto3-greengrass (==1.17.5.0)", "mypy-boto3-greengrassv2 (==1.17.5.0)", "mypy-boto3-groundstation (==1.17.5.0)", "mypy-boto3-guardduty (==1.17.5.0)", "mypy-boto3-health (==1.17.5.0)", "mypy-boto3-healthlake (==1.17.5.0)", "mypy-boto3-honeycode (==1.17.5.0)", "mypy-boto3-iam (==1.17.5.0)", "mypy-boto3-identitystore (==1.17.5.0)", "mypy-boto3-imagebuilder (==1.17.5.0)", "mypy-boto3-importexport (==1.17.5.0)", "mypy-boto3-inspector (==1.17.5.0)", "mypy-boto3-iot (==1.17.5.0)", "mypy-boto3-iot-data (==1.17.5.0)", "mypy-boto3-iot-jobs-data (==1.17.5.0)", "mypy-boto3-iot1click-devices (==1.17.5.0)", "mypy-boto3-iot1click-projects (==1.17.5.0)", "mypy-boto3-iotanalytics (==1.17.5.0)", "mypy-boto3-iotdeviceadvisor (==1.17.5.0)", "mypy-boto3-iotevents (==1.17.5.0)", "mypy-boto3-iotevents-data (==1.17.5.0)", "mypy-boto3-iotfleethub (==1.17.5.0)", "mypy-boto3-iotsecuretunneling (==1.17.5.0)", "mypy-boto3-iotsitewise (==1.17.5.0)", "mypy-boto3-iotthingsgraph (==1.17.5.0)", "mypy-boto3-iotwireless (==1.17.5.0)", "mypy-boto3-ivs (==1.17.5.0)", "mypy-boto3-kafka (==1.17.5.0)", "mypy-boto3-kendra (==1.17.5.0)", "mypy-boto3-kinesis (==1.17.5.0)", "mypy-boto3-kinesis-video-archived-media (==1.17.5.0)", "mypy-boto3-kinesis-video-media (==1.17.5.0)", "mypy-boto3-kinesis-video-signaling (==1.17.5.0)", "mypy-boto3-kinesisanalytics (==1.17.5.0)", "mypy-boto3-kinesisanalyticsv2 (==1.17.5.0)", "mypy-boto3-kinesisvideo (==1.17.5.0)", "mypy-boto3-kms (==1.17.5.0)", "mypy-boto3-lakeformation (==1.17.5.0)", "mypy-boto3-lambda (==1.17.5.0)", "mypy-boto3-lex-models (==1.17.5.0)", "mypy-boto3-lex-runtime (==1.17.5.0)", "mypy-boto3-lexv2-models (==1.17.5.0)", "mypy-boto3-lexv2-runtime (==1.17.5.0)", "mypy-boto3-license-manager (==1.17.5.0)", "mypy-boto3-lightsail (==1.17.5.0)", "mypy-boto3-location (==1.17.5.0)", "mypy-boto3-logs (==1.17.5.0)", "mypy-boto3-lookoutvision (==1.17.5.0)", "mypy-boto3-machinelearning (==1.17.5.0)", "mypy-boto3-macie (==1.17.5.0)", "mypy-boto3-macie2 (==1.17.5.0)", "mypy-boto3-managedblockchain (==1.17.5.0)", "mypy-boto3-marketplace-catalog (==1.17.5.0)", "mypy-boto3-marketplace-entitlement (==1.17.5.0)", "mypy-boto3-marketplacecommerceanalytics (==1.17.5.0)", "mypy-boto3-mediaconnect (==1.17.5.0)", "mypy-boto3-mediaconvert (==1.17.5.0)", "mypy-boto3-medialive (==1.17.5.0)", "mypy-boto3-mediapackage (==1.17.5.0)", "mypy-boto3-mediapackage-vod (==1.17.5.0)", "mypy-boto3-mediastore (==1.17.5.0)", "mypy-boto3-mediastore-data (==1.17.5.0)", "mypy-boto3-mediatailor (==1.17.5.0)", "mypy-boto3-meteringmarketplace (==1.17.5.0)", "mypy-boto3-mgh (==1.17.5.0)", "mypy-boto3-migrationhub-config (==1.17.5.0)", "mypy-boto3-mobile (==1.17.5.0)", "mypy-boto3-mq (==1.17.5.0)", "mypy-boto3-mturk (==1.17.5.0)", "mypy-boto3-mwaa (==1.17.5.0)", "mypy-boto3-neptune (==1.17.5.0)", "mypy-boto3-network-firewall (==1.17.5.0)", "mypy-boto3-networkmanager (==1.17.5.0)", "mypy-boto3-opsworks (==1.17.5.0)", "mypy-boto3-opsworkscm (==1.17.5.0)", "mypy-boto3-organizations (==1.17.5.0)", "mypy-boto3-outposts (==1.17.5.0)", "mypy-boto3-personalize (==1.17.5.0)", "mypy-boto3-personalize-events (==1.17.5.0)", "mypy-boto3-personalize-runtime (==1.17.5.0)", "mypy-boto3-pi (==1.17.5.0)", "mypy-boto3-pinpoint (==1.17.5.0)", "mypy-boto3-pinpoint-email (==1.17.5.0)", "mypy-boto3-pinpoint-sms-voice (==1.17.5.0)", "mypy-boto3-polly (==1.17.5.0)", "mypy-boto3-pricing (==1.17.5.0)", "mypy-boto3-qldb (==1.17.5.0)", "mypy-boto3-qldb-session (==1.17.5.0)", "mypy-boto3-quicksight (==1.17.5.0)", "mypy-boto3-ram (==1.17.5.0)", "mypy-boto3-rds (==1.17.5.0)", "mypy-boto3-rds-data (==1.17.5.0)", "mypy-boto3-redshift (==1.17.5.0)", "mypy-boto3-redshift-data (==1.17.5.0)", "mypy-boto3-rekognition (==1.17.5.0)", "mypy-boto3-resource-groups (==1.17.5.0)", "mypy-boto3-resourcegroupstaggingapi (==1.17.5.0)", "mypy-boto3-robomaker (==1.17.5.0)", "mypy-boto3-route53 (==1.17.5.0)", "mypy-boto3-route53domains (==1.17.5.0)", "mypy-boto3-route53resolver (==1.17.5.0)", "mypy-boto3-s3 (==1.17.5.0)", "mypy-boto3-s3control (==1.17.5.0)", "mypy-boto3-s3outposts (==1.17.5.0)", "mypy-boto3-sagemaker (==1.17.5.0)", "mypy-boto3-sagemaker-a2i-runtime (==1.17.5.0)", "mypy-boto3-sagemaker-edge (==1.17.5.0)", "mypy-boto3-sagemaker-featurestore-runtime (==1.17.5.0)", "mypy-boto3-sagemaker-runtime (==1.17.5.0)", "mypy-boto3-savingsplans (==1.17.5.0)", "mypy-boto3-schemas (==1.17.5.0)", "mypy-boto3-sdb (==1.17.5.0)", "mypy-boto3-secretsmanager (==1.17.5.0)", "mypy-boto3-securityhub (==1.17.5.0)", "mypy-boto3-serverlessrepo (==1.17.5.0)", "mypy-boto3-service-quotas (==1.17.5.0)", "mypy-boto3-servicecatalog (==1.17.5.0)", "mypy-boto3-servicecatalog-appregistry (==1.17.5.0)", "mypy-boto3-servicediscovery (==1.17.5.0)", "mypy-boto3-ses (==1.17.5.0)", "mypy-boto3-sesv2 (==1.17.5.0)", "mypy-boto3-shield (==1.17.5.0)", "mypy-boto3-signer (==1.17.5.0)", "mypy-boto3-sms (==1.17.5.0)", "mypy-boto3-sms-voice (==1.17.5.0)", "mypy-boto3-snowball (==1.17.5.0)", "mypy-boto3-sns (==1.17.5.0)", "mypy-boto3-sqs (==1.17.5.0)", "mypy-boto3-ssm (==1.17.5.0)", "mypy-boto3-sso (==1.17.5.0)", "mypy-boto3-sso-admin (==1.17.5.0)", "mypy-boto3-sso-oidc (==1.17.5.0)", "mypy-boto3-stepfunctions (==1.17.5.0)", "mypy-boto3-storagegateway (==1.17.5.0)", "mypy-boto3-sts (==1.17.5.0)", "mypy-boto3-support (==1.17.5.0)", "mypy-boto3-swf (==1.17.5.0)", "mypy-boto3-synthetics (==1.17.5.0)", "mypy-boto3-textract (==1.17.5.0)", "mypy-boto3-timestream-query (==1.17.5.0)", "mypy-boto3-timestream-write (==1.17.5.0)", "mypy-boto3-transcribe (==1.17.5.0)", "mypy-boto3-transfer (==1.17.5.0)", "mypy-boto3-translate (==1.17.5.0)", "mypy-boto3-waf (==1.17.5.0)", "mypy-boto3-waf-regional (==1.17.5.0)", "mypy-boto3-wafv2 (==1.17.5.0)", "mypy-boto3-wellarchitected (==1.17.5.0)", "mypy-boto3-workdocs (==1.17.5.0)", "mypy-boto3-worklink (==1.17.5.0)", "mypy-boto3-workmail (==1.17.5.0)", "mypy-boto3-workmailmessageflow (==1.17.5.0)", "mypy-boto3-workspaces (==1.17.5.0)", "mypy-boto3-xray (==1.17.5.0)"]
-amp = ["mypy-boto3-amp (==1.17.5.0)"]
-amplify = ["mypy-boto3-amplify (==1.17.5.0)"]
-amplifybackend = ["mypy-boto3-amplifybackend (==1.17.5.0)"]
-apigateway = ["mypy-boto3-apigateway (==1.17.5.0)"]
-apigatewaymanagementapi = ["mypy-boto3-apigatewaymanagementapi (==1.17.5.0)"]
-apigatewayv2 = ["mypy-boto3-apigatewayv2 (==1.17.5.0)"]
-appconfig = ["mypy-boto3-appconfig (==1.17.5.0)"]
-appflow = ["mypy-boto3-appflow (==1.17.5.0)"]
-appintegrations = ["mypy-boto3-appintegrations (==1.17.5.0)"]
-application-autoscaling = ["mypy-boto3-application-autoscaling (==1.17.5.0)"]
-application-insights = ["mypy-boto3-application-insights (==1.17.5.0)"]
-appmesh = ["mypy-boto3-appmesh (==1.17.5.0)"]
-appstream = ["mypy-boto3-appstream (==1.17.5.0)"]
-appsync = ["mypy-boto3-appsync (==1.17.5.0)"]
-athena = ["mypy-boto3-athena (==1.17.5.0)"]
-auditmanager = ["mypy-boto3-auditmanager (==1.17.5.0)"]
-autoscaling = ["mypy-boto3-autoscaling (==1.17.5.0)"]
-autoscaling-plans = ["mypy-boto3-autoscaling-plans (==1.17.5.0)"]
-backup = ["mypy-boto3-backup (==1.17.5.0)"]
-batch = ["mypy-boto3-batch (==1.17.5.0)"]
-braket = ["mypy-boto3-braket (==1.17.5.0)"]
-budgets = ["mypy-boto3-budgets (==1.17.5.0)"]
-ce = ["mypy-boto3-ce (==1.17.5.0)"]
-chime = ["mypy-boto3-chime (==1.17.5.0)"]
-cloud9 = ["mypy-boto3-cloud9 (==1.17.5.0)"]
-clouddirectory = ["mypy-boto3-clouddirectory (==1.17.5.0)"]
-cloudformation = ["mypy-boto3-cloudformation (==1.17.5.0)"]
-cloudfront = ["mypy-boto3-cloudfront (==1.17.5.0)"]
-cloudhsm = ["mypy-boto3-cloudhsm (==1.17.5.0)"]
-cloudhsmv2 = ["mypy-boto3-cloudhsmv2 (==1.17.5.0)"]
-cloudsearch = ["mypy-boto3-cloudsearch (==1.17.5.0)"]
-cloudsearchdomain = ["mypy-boto3-cloudsearchdomain (==1.17.5.0)"]
-cloudtrail = ["mypy-boto3-cloudtrail (==1.17.5.0)"]
-cloudwatch = ["mypy-boto3-cloudwatch (==1.17.5.0)"]
-codeartifact = ["mypy-boto3-codeartifact (==1.17.5.0)"]
-codebuild = ["mypy-boto3-codebuild (==1.17.5.0)"]
-codecommit = ["mypy-boto3-codecommit (==1.17.5.0)"]
-codedeploy = ["mypy-boto3-codedeploy (==1.17.5.0)"]
-codeguru-reviewer = ["mypy-boto3-codeguru-reviewer (==1.17.5.0)"]
-codeguruprofiler = ["mypy-boto3-codeguruprofiler (==1.17.5.0)"]
-codepipeline = ["mypy-boto3-codepipeline (==1.17.5.0)"]
-codestar = ["mypy-boto3-codestar (==1.17.5.0)"]
-codestar-connections = ["mypy-boto3-codestar-connections (==1.17.5.0)"]
-codestar-notifications = ["mypy-boto3-codestar-notifications (==1.17.5.0)"]
-cognito-identity = ["mypy-boto3-cognito-identity (==1.17.5.0)"]
-cognito-idp = ["mypy-boto3-cognito-idp (==1.17.5.0)"]
-cognito-sync = ["mypy-boto3-cognito-sync (==1.17.5.0)"]
-comprehend = ["mypy-boto3-comprehend (==1.17.5.0)"]
-comprehendmedical = ["mypy-boto3-comprehendmedical (==1.17.5.0)"]
-compute-optimizer = ["mypy-boto3-compute-optimizer (==1.17.5.0)"]
-config = ["mypy-boto3-config (==1.17.5.0)"]
-connect = ["mypy-boto3-connect (==1.17.5.0)"]
-connect-contact-lens = ["mypy-boto3-connect-contact-lens (==1.17.5.0)"]
-connectparticipant = ["mypy-boto3-connectparticipant (==1.17.5.0)"]
-cur = ["mypy-boto3-cur (==1.17.5.0)"]
-customer-profiles = ["mypy-boto3-customer-profiles (==1.17.5.0)"]
-databrew = ["mypy-boto3-databrew (==1.17.5.0)"]
-dataexchange = ["mypy-boto3-dataexchange (==1.17.5.0)"]
-datapipeline = ["mypy-boto3-datapipeline (==1.17.5.0)"]
-datasync = ["mypy-boto3-datasync (==1.17.5.0)"]
-dax = ["mypy-boto3-dax (==1.17.5.0)"]
-detective = ["mypy-boto3-detective (==1.17.5.0)"]
-devicefarm = ["mypy-boto3-devicefarm (==1.17.5.0)"]
-devops-guru = ["mypy-boto3-devops-guru (==1.17.5.0)"]
-directconnect = ["mypy-boto3-directconnect (==1.17.5.0)"]
-discovery = ["mypy-boto3-discovery (==1.17.5.0)"]
-dlm = ["mypy-boto3-dlm (==1.17.5.0)"]
-dms = ["mypy-boto3-dms (==1.17.5.0)"]
-docdb = ["mypy-boto3-docdb (==1.17.5.0)"]
-ds = ["mypy-boto3-ds (==1.17.5.0)"]
-dynamodb = ["mypy-boto3-dynamodb (==1.17.5.0)"]
-dynamodbstreams = ["mypy-boto3-dynamodbstreams (==1.17.5.0)"]
-ebs = ["mypy-boto3-ebs (==1.17.5.0)"]
-ec2 = ["mypy-boto3-ec2 (==1.17.5.0)"]
-ec2-instance-connect = ["mypy-boto3-ec2-instance-connect (==1.17.5.0)"]
-ecr = ["mypy-boto3-ecr (==1.17.5.0)"]
-ecr-public = ["mypy-boto3-ecr-public (==1.17.5.0)"]
-ecs = ["mypy-boto3-ecs (==1.17.5.0)"]
-efs = ["mypy-boto3-efs (==1.17.5.0)"]
-eks = ["mypy-boto3-eks (==1.17.5.0)"]
-elastic-inference = ["mypy-boto3-elastic-inference (==1.17.5.0)"]
-elasticache = ["mypy-boto3-elasticache (==1.17.5.0)"]
-elasticbeanstalk = ["mypy-boto3-elasticbeanstalk (==1.17.5.0)"]
-elastictranscoder = ["mypy-boto3-elastictranscoder (==1.17.5.0)"]
-elb = ["mypy-boto3-elb (==1.17.5.0)"]
-elbv2 = ["mypy-boto3-elbv2 (==1.17.5.0)"]
-emr = ["mypy-boto3-emr (==1.17.5.0)"]
-emr-containers = ["mypy-boto3-emr-containers (==1.17.5.0)"]
-es = ["mypy-boto3-es (==1.17.5.0)"]
-essential = ["mypy-boto3-cloudformation (==1.17.5.0)", "mypy-boto3-dynamodb (==1.17.5.0)", "mypy-boto3-ec2 (==1.17.5.0)", "mypy-boto3-lambda (==1.17.5.0)", "mypy-boto3-rds (==1.17.5.0)", "mypy-boto3-s3 (==1.17.5.0)", "mypy-boto3-sqs (==1.17.5.0)"]
-events = ["mypy-boto3-events (==1.17.5.0)"]
-firehose = ["mypy-boto3-firehose (==1.17.5.0)"]
-fms = ["mypy-boto3-fms (==1.17.5.0)"]
-forecast = ["mypy-boto3-forecast (==1.17.5.0)"]
-forecastquery = ["mypy-boto3-forecastquery (==1.17.5.0)"]
-frauddetector = ["mypy-boto3-frauddetector (==1.17.5.0)"]
-fsx = ["mypy-boto3-fsx (==1.17.5.0)"]
-gamelift = ["mypy-boto3-gamelift (==1.17.5.0)"]
-glacier = ["mypy-boto3-glacier (==1.17.5.0)"]
-globalaccelerator = ["mypy-boto3-globalaccelerator (==1.17.5.0)"]
-glue = ["mypy-boto3-glue (==1.17.5.0)"]
-greengrass = ["mypy-boto3-greengrass (==1.17.5.0)"]
-greengrassv2 = ["mypy-boto3-greengrassv2 (==1.17.5.0)"]
-groundstation = ["mypy-boto3-groundstation (==1.17.5.0)"]
-guardduty = ["mypy-boto3-guardduty (==1.17.5.0)"]
-health = ["mypy-boto3-health (==1.17.5.0)"]
-healthlake = ["mypy-boto3-healthlake (==1.17.5.0)"]
-honeycode = ["mypy-boto3-honeycode (==1.17.5.0)"]
-iam = ["mypy-boto3-iam (==1.17.5.0)"]
-identitystore = ["mypy-boto3-identitystore (==1.17.5.0)"]
-imagebuilder = ["mypy-boto3-imagebuilder (==1.17.5.0)"]
-importexport = ["mypy-boto3-importexport (==1.17.5.0)"]
-inspector = ["mypy-boto3-inspector (==1.17.5.0)"]
-iot = ["mypy-boto3-iot (==1.17.5.0)"]
-iot-data = ["mypy-boto3-iot-data (==1.17.5.0)"]
-iot-jobs-data = ["mypy-boto3-iot-jobs-data (==1.17.5.0)"]
-iot1click-devices = ["mypy-boto3-iot1click-devices (==1.17.5.0)"]
-iot1click-projects = ["mypy-boto3-iot1click-projects (==1.17.5.0)"]
-iotanalytics = ["mypy-boto3-iotanalytics (==1.17.5.0)"]
-iotdeviceadvisor = ["mypy-boto3-iotdeviceadvisor (==1.17.5.0)"]
-iotevents = ["mypy-boto3-iotevents (==1.17.5.0)"]
-iotevents-data = ["mypy-boto3-iotevents-data (==1.17.5.0)"]
-iotfleethub = ["mypy-boto3-iotfleethub (==1.17.5.0)"]
-iotsecuretunneling = ["mypy-boto3-iotsecuretunneling (==1.17.5.0)"]
-iotsitewise = ["mypy-boto3-iotsitewise (==1.17.5.0)"]
-iotthingsgraph = ["mypy-boto3-iotthingsgraph (==1.17.5.0)"]
-iotwireless = ["mypy-boto3-iotwireless (==1.17.5.0)"]
-ivs = ["mypy-boto3-ivs (==1.17.5.0)"]
-kafka = ["mypy-boto3-kafka (==1.17.5.0)"]
-kendra = ["mypy-boto3-kendra (==1.17.5.0)"]
-kinesis = ["mypy-boto3-kinesis (==1.17.5.0)"]
-kinesis-video-archived-media = ["mypy-boto3-kinesis-video-archived-media (==1.17.5.0)"]
-kinesis-video-media = ["mypy-boto3-kinesis-video-media (==1.17.5.0)"]
-kinesis-video-signaling = ["mypy-boto3-kinesis-video-signaling (==1.17.5.0)"]
-kinesisanalytics = ["mypy-boto3-kinesisanalytics (==1.17.5.0)"]
-kinesisanalyticsv2 = ["mypy-boto3-kinesisanalyticsv2 (==1.17.5.0)"]
-kinesisvideo = ["mypy-boto3-kinesisvideo (==1.17.5.0)"]
-kms = ["mypy-boto3-kms (==1.17.5.0)"]
-lakeformation = ["mypy-boto3-lakeformation (==1.17.5.0)"]
-lambda = ["mypy-boto3-lambda (==1.17.5.0)"]
-lex-models = ["mypy-boto3-lex-models (==1.17.5.0)"]
-lex-runtime = ["mypy-boto3-lex-runtime (==1.17.5.0)"]
-lexv2-models = ["mypy-boto3-lexv2-models (==1.17.5.0)"]
-lexv2-runtime = ["mypy-boto3-lexv2-runtime (==1.17.5.0)"]
-license-manager = ["mypy-boto3-license-manager (==1.17.5.0)"]
-lightsail = ["mypy-boto3-lightsail (==1.17.5.0)"]
-location = ["mypy-boto3-location (==1.17.5.0)"]
-logs = ["mypy-boto3-logs (==1.17.5.0)"]
-lookoutvision = ["mypy-boto3-lookoutvision (==1.17.5.0)"]
-machinelearning = ["mypy-boto3-machinelearning (==1.17.5.0)"]
-macie = ["mypy-boto3-macie (==1.17.5.0)"]
-macie2 = ["mypy-boto3-macie2 (==1.17.5.0)"]
-managedblockchain = ["mypy-boto3-managedblockchain (==1.17.5.0)"]
-marketplace-catalog = ["mypy-boto3-marketplace-catalog (==1.17.5.0)"]
-marketplace-entitlement = ["mypy-boto3-marketplace-entitlement (==1.17.5.0)"]
-marketplacecommerceanalytics = ["mypy-boto3-marketplacecommerceanalytics (==1.17.5.0)"]
-mediaconnect = ["mypy-boto3-mediaconnect (==1.17.5.0)"]
-mediaconvert = ["mypy-boto3-mediaconvert (==1.17.5.0)"]
-medialive = ["mypy-boto3-medialive (==1.17.5.0)"]
-mediapackage = ["mypy-boto3-mediapackage (==1.17.5.0)"]
-mediapackage-vod = ["mypy-boto3-mediapackage-vod (==1.17.5.0)"]
-mediastore = ["mypy-boto3-mediastore (==1.17.5.0)"]
-mediastore-data = ["mypy-boto3-mediastore-data (==1.17.5.0)"]
-mediatailor = ["mypy-boto3-mediatailor (==1.17.5.0)"]
-meteringmarketplace = ["mypy-boto3-meteringmarketplace (==1.17.5.0)"]
-mgh = ["mypy-boto3-mgh (==1.17.5.0)"]
-migrationhub-config = ["mypy-boto3-migrationhub-config (==1.17.5.0)"]
-mobile = ["mypy-boto3-mobile (==1.17.5.0)"]
-mq = ["mypy-boto3-mq (==1.17.5.0)"]
-mturk = ["mypy-boto3-mturk (==1.17.5.0)"]
-mwaa = ["mypy-boto3-mwaa (==1.17.5.0)"]
-neptune = ["mypy-boto3-neptune (==1.17.5.0)"]
-network-firewall = ["mypy-boto3-network-firewall (==1.17.5.0)"]
-networkmanager = ["mypy-boto3-networkmanager (==1.17.5.0)"]
-opsworks = ["mypy-boto3-opsworks (==1.17.5.0)"]
-opsworkscm = ["mypy-boto3-opsworkscm (==1.17.5.0)"]
-organizations = ["mypy-boto3-organizations (==1.17.5.0)"]
-outposts = ["mypy-boto3-outposts (==1.17.5.0)"]
-personalize = ["mypy-boto3-personalize (==1.17.5.0)"]
-personalize-events = ["mypy-boto3-personalize-events (==1.17.5.0)"]
-personalize-runtime = ["mypy-boto3-personalize-runtime (==1.17.5.0)"]
-pi = ["mypy-boto3-pi (==1.17.5.0)"]
-pinpoint = ["mypy-boto3-pinpoint (==1.17.5.0)"]
-pinpoint-email = ["mypy-boto3-pinpoint-email (==1.17.5.0)"]
-pinpoint-sms-voice = ["mypy-boto3-pinpoint-sms-voice (==1.17.5.0)"]
-polly = ["mypy-boto3-polly (==1.17.5.0)"]
-pricing = ["mypy-boto3-pricing (==1.17.5.0)"]
-qldb = ["mypy-boto3-qldb (==1.17.5.0)"]
-qldb-session = ["mypy-boto3-qldb-session (==1.17.5.0)"]
-quicksight = ["mypy-boto3-quicksight (==1.17.5.0)"]
-ram = ["mypy-boto3-ram (==1.17.5.0)"]
-rds = ["mypy-boto3-rds (==1.17.5.0)"]
-rds-data = ["mypy-boto3-rds-data (==1.17.5.0)"]
-redshift = ["mypy-boto3-redshift (==1.17.5.0)"]
-redshift-data = ["mypy-boto3-redshift-data (==1.17.5.0)"]
-rekognition = ["mypy-boto3-rekognition (==1.17.5.0)"]
-resource-groups = ["mypy-boto3-resource-groups (==1.17.5.0)"]
-resourcegroupstaggingapi = ["mypy-boto3-resourcegroupstaggingapi (==1.17.5.0)"]
-robomaker = ["mypy-boto3-robomaker (==1.17.5.0)"]
-route53 = ["mypy-boto3-route53 (==1.17.5.0)"]
-route53domains = ["mypy-boto3-route53domains (==1.17.5.0)"]
-route53resolver = ["mypy-boto3-route53resolver (==1.17.5.0)"]
-s3 = ["mypy-boto3-s3 (==1.17.5.0)"]
-s3control = ["mypy-boto3-s3control (==1.17.5.0)"]
-s3outposts = ["mypy-boto3-s3outposts (==1.17.5.0)"]
-sagemaker = ["mypy-boto3-sagemaker (==1.17.5.0)"]
-sagemaker-a2i-runtime = ["mypy-boto3-sagemaker-a2i-runtime (==1.17.5.0)"]
-sagemaker-edge = ["mypy-boto3-sagemaker-edge (==1.17.5.0)"]
-sagemaker-featurestore-runtime = ["mypy-boto3-sagemaker-featurestore-runtime (==1.17.5.0)"]
-sagemaker-runtime = ["mypy-boto3-sagemaker-runtime (==1.17.5.0)"]
-savingsplans = ["mypy-boto3-savingsplans (==1.17.5.0)"]
-schemas = ["mypy-boto3-schemas (==1.17.5.0)"]
-sdb = ["mypy-boto3-sdb (==1.17.5.0)"]
-secretsmanager = ["mypy-boto3-secretsmanager (==1.17.5.0)"]
-securityhub = ["mypy-boto3-securityhub (==1.17.5.0)"]
-serverlessrepo = ["mypy-boto3-serverlessrepo (==1.17.5.0)"]
-service-quotas = ["mypy-boto3-service-quotas (==1.17.5.0)"]
-servicecatalog = ["mypy-boto3-servicecatalog (==1.17.5.0)"]
-servicecatalog-appregistry = ["mypy-boto3-servicecatalog-appregistry (==1.17.5.0)"]
-servicediscovery = ["mypy-boto3-servicediscovery (==1.17.5.0)"]
-ses = ["mypy-boto3-ses (==1.17.5.0)"]
-sesv2 = ["mypy-boto3-sesv2 (==1.17.5.0)"]
-shield = ["mypy-boto3-shield (==1.17.5.0)"]
-signer = ["mypy-boto3-signer (==1.17.5.0)"]
-sms = ["mypy-boto3-sms (==1.17.5.0)"]
-sms-voice = ["mypy-boto3-sms-voice (==1.17.5.0)"]
-snowball = ["mypy-boto3-snowball (==1.17.5.0)"]
-sns = ["mypy-boto3-sns (==1.17.5.0)"]
-sqs = ["mypy-boto3-sqs (==1.17.5.0)"]
-ssm = ["mypy-boto3-ssm (==1.17.5.0)"]
-sso = ["mypy-boto3-sso (==1.17.5.0)"]
-sso-admin = ["mypy-boto3-sso-admin (==1.17.5.0)"]
-sso-oidc = ["mypy-boto3-sso-oidc (==1.17.5.0)"]
-stepfunctions = ["mypy-boto3-stepfunctions (==1.17.5.0)"]
-storagegateway = ["mypy-boto3-storagegateway (==1.17.5.0)"]
-sts = ["mypy-boto3-sts (==1.17.5.0)"]
-support = ["mypy-boto3-support (==1.17.5.0)"]
-swf = ["mypy-boto3-swf (==1.17.5.0)"]
-synthetics = ["mypy-boto3-synthetics (==1.17.5.0)"]
-textract = ["mypy-boto3-textract (==1.17.5.0)"]
-timestream-query = ["mypy-boto3-timestream-query (==1.17.5.0)"]
-timestream-write = ["mypy-boto3-timestream-write (==1.17.5.0)"]
-transcribe = ["mypy-boto3-transcribe (==1.17.5.0)"]
-transfer = ["mypy-boto3-transfer (==1.17.5.0)"]
-translate = ["mypy-boto3-translate (==1.17.5.0)"]
-waf = ["mypy-boto3-waf (==1.17.5.0)"]
-waf-regional = ["mypy-boto3-waf-regional (==1.17.5.0)"]
-wafv2 = ["mypy-boto3-wafv2 (==1.17.5.0)"]
-wellarchitected = ["mypy-boto3-wellarchitected (==1.17.5.0)"]
-workdocs = ["mypy-boto3-workdocs (==1.17.5.0)"]
-worklink = ["mypy-boto3-worklink (==1.17.5.0)"]
-workmail = ["mypy-boto3-workmail (==1.17.5.0)"]
-workmailmessageflow = ["mypy-boto3-workmailmessageflow (==1.17.5.0)"]
-workspaces = ["mypy-boto3-workspaces (==1.17.5.0)"]
-xray = ["mypy-boto3-xray (==1.17.5.0)"]
+accessanalyzer = ["mypy-boto3-accessanalyzer (==1.17.6.0)"]
+acm = ["mypy-boto3-acm (==1.17.6.0)"]
+acm-pca = ["mypy-boto3-acm-pca (==1.17.6.0)"]
+alexaforbusiness = ["mypy-boto3-alexaforbusiness (==1.17.6.0)"]
+all = ["mypy-boto3-accessanalyzer (==1.17.6.0)", "mypy-boto3-acm (==1.17.6.0)", "mypy-boto3-acm-pca (==1.17.6.0)", "mypy-boto3-alexaforbusiness (==1.17.6.0)", "mypy-boto3-amp (==1.17.6.0)", "mypy-boto3-amplify (==1.17.6.0)", "mypy-boto3-amplifybackend (==1.17.6.0)", "mypy-boto3-apigateway (==1.17.6.0)", "mypy-boto3-apigatewaymanagementapi (==1.17.6.0)", "mypy-boto3-apigatewayv2 (==1.17.6.0)", "mypy-boto3-appconfig (==1.17.6.0)", "mypy-boto3-appflow (==1.17.6.0)", "mypy-boto3-appintegrations (==1.17.6.0)", "mypy-boto3-application-autoscaling (==1.17.6.0)", "mypy-boto3-application-insights (==1.17.6.0)", "mypy-boto3-appmesh (==1.17.6.0)", "mypy-boto3-appstream (==1.17.6.0)", "mypy-boto3-appsync (==1.17.6.0)", "mypy-boto3-athena (==1.17.6.0)", "mypy-boto3-auditmanager (==1.17.6.0)", "mypy-boto3-autoscaling (==1.17.6.0)", "mypy-boto3-autoscaling-plans (==1.17.6.0)", "mypy-boto3-backup (==1.17.6.0)", "mypy-boto3-batch (==1.17.6.0)", "mypy-boto3-braket (==1.17.6.0)", "mypy-boto3-budgets (==1.17.6.0)", "mypy-boto3-ce (==1.17.6.0)", "mypy-boto3-chime (==1.17.6.0)", "mypy-boto3-cloud9 (==1.17.6.0)", "mypy-boto3-clouddirectory (==1.17.6.0)", "mypy-boto3-cloudformation (==1.17.6.0)", "mypy-boto3-cloudfront (==1.17.6.0)", "mypy-boto3-cloudhsm (==1.17.6.0)", "mypy-boto3-cloudhsmv2 (==1.17.6.0)", "mypy-boto3-cloudsearch (==1.17.6.0)", "mypy-boto3-cloudsearchdomain (==1.17.6.0)", "mypy-boto3-cloudtrail (==1.17.6.0)", "mypy-boto3-cloudwatch (==1.17.6.0)", "mypy-boto3-codeartifact (==1.17.6.0)", "mypy-boto3-codebuild (==1.17.6.0)", "mypy-boto3-codecommit (==1.17.6.0)", "mypy-boto3-codedeploy (==1.17.6.0)", "mypy-boto3-codeguru-reviewer (==1.17.6.0)", "mypy-boto3-codeguruprofiler (==1.17.6.0)", "mypy-boto3-codepipeline (==1.17.6.0)", "mypy-boto3-codestar (==1.17.6.0)", "mypy-boto3-codestar-connections (==1.17.6.0)", "mypy-boto3-codestar-notifications (==1.17.6.0)", "mypy-boto3-cognito-identity (==1.17.6.0)", "mypy-boto3-cognito-idp (==1.17.6.0)", "mypy-boto3-cognito-sync (==1.17.6.0)", "mypy-boto3-comprehend (==1.17.6.0)", "mypy-boto3-comprehendmedical (==1.17.6.0)", "mypy-boto3-compute-optimizer (==1.17.6.0)", "mypy-boto3-config (==1.17.6.0)", "mypy-boto3-connect (==1.17.6.0)", "mypy-boto3-connect-contact-lens (==1.17.6.0)", "mypy-boto3-connectparticipant (==1.17.6.0)", "mypy-boto3-cur (==1.17.6.0)", "mypy-boto3-customer-profiles (==1.17.6.0)", "mypy-boto3-databrew (==1.17.6.0)", "mypy-boto3-dataexchange (==1.17.6.0)", "mypy-boto3-datapipeline (==1.17.6.0)", "mypy-boto3-datasync (==1.17.6.0)", "mypy-boto3-dax (==1.17.6.0)", "mypy-boto3-detective (==1.17.6.0)", "mypy-boto3-devicefarm (==1.17.6.0)", "mypy-boto3-devops-guru (==1.17.6.0)", "mypy-boto3-directconnect (==1.17.6.0)", "mypy-boto3-discovery (==1.17.6.0)", "mypy-boto3-dlm (==1.17.6.0)", "mypy-boto3-dms (==1.17.6.0)", "mypy-boto3-docdb (==1.17.6.0)", "mypy-boto3-ds (==1.17.6.0)", "mypy-boto3-dynamodb (==1.17.6.0)", "mypy-boto3-dynamodbstreams (==1.17.6.0)", "mypy-boto3-ebs (==1.17.6.0)", "mypy-boto3-ec2 (==1.17.6.0)", "mypy-boto3-ec2-instance-connect (==1.17.6.0)", "mypy-boto3-ecr (==1.17.6.0)", "mypy-boto3-ecr-public (==1.17.6.0)", "mypy-boto3-ecs (==1.17.6.0)", "mypy-boto3-efs (==1.17.6.0)", "mypy-boto3-eks (==1.17.6.0)", "mypy-boto3-elastic-inference (==1.17.6.0)", "mypy-boto3-elasticache (==1.17.6.0)", "mypy-boto3-elasticbeanstalk (==1.17.6.0)", "mypy-boto3-elastictranscoder (==1.17.6.0)", "mypy-boto3-elb (==1.17.6.0)", "mypy-boto3-elbv2 (==1.17.6.0)", "mypy-boto3-emr (==1.17.6.0)", "mypy-boto3-emr-containers (==1.17.6.0)", "mypy-boto3-es (==1.17.6.0)", "mypy-boto3-events (==1.17.6.0)", "mypy-boto3-firehose (==1.17.6.0)", "mypy-boto3-fms (==1.17.6.0)", "mypy-boto3-forecast (==1.17.6.0)", "mypy-boto3-forecastquery (==1.17.6.0)", "mypy-boto3-frauddetector (==1.17.6.0)", "mypy-boto3-fsx (==1.17.6.0)", "mypy-boto3-gamelift (==1.17.6.0)", "mypy-boto3-glacier (==1.17.6.0)", "mypy-boto3-globalaccelerator (==1.17.6.0)", "mypy-boto3-glue (==1.17.6.0)", "mypy-boto3-greengrass (==1.17.6.0)", "mypy-boto3-greengrassv2 (==1.17.6.0)", "mypy-boto3-groundstation (==1.17.6.0)", "mypy-boto3-guardduty (==1.17.6.0)", "mypy-boto3-health (==1.17.6.0)", "mypy-boto3-healthlake (==1.17.6.0)", "mypy-boto3-honeycode (==1.17.6.0)", "mypy-boto3-iam (==1.17.6.0)", "mypy-boto3-identitystore (==1.17.6.0)", "mypy-boto3-imagebuilder (==1.17.6.0)", "mypy-boto3-importexport (==1.17.6.0)", "mypy-boto3-inspector (==1.17.6.0)", "mypy-boto3-iot (==1.17.6.0)", "mypy-boto3-iot-data (==1.17.6.0)", "mypy-boto3-iot-jobs-data (==1.17.6.0)", "mypy-boto3-iot1click-devices (==1.17.6.0)", "mypy-boto3-iot1click-projects (==1.17.6.0)", "mypy-boto3-iotanalytics (==1.17.6.0)", "mypy-boto3-iotdeviceadvisor (==1.17.6.0)", "mypy-boto3-iotevents (==1.17.6.0)", "mypy-boto3-iotevents-data (==1.17.6.0)", "mypy-boto3-iotfleethub (==1.17.6.0)", "mypy-boto3-iotsecuretunneling (==1.17.6.0)", "mypy-boto3-iotsitewise (==1.17.6.0)", "mypy-boto3-iotthingsgraph (==1.17.6.0)", "mypy-boto3-iotwireless (==1.17.6.0)", "mypy-boto3-ivs (==1.17.6.0)", "mypy-boto3-kafka (==1.17.6.0)", "mypy-boto3-kendra (==1.17.6.0)", "mypy-boto3-kinesis (==1.17.6.0)", "mypy-boto3-kinesis-video-archived-media (==1.17.6.0)", "mypy-boto3-kinesis-video-media (==1.17.6.0)", "mypy-boto3-kinesis-video-signaling (==1.17.6.0)", "mypy-boto3-kinesisanalytics (==1.17.6.0)", "mypy-boto3-kinesisanalyticsv2 (==1.17.6.0)", "mypy-boto3-kinesisvideo (==1.17.6.0)", "mypy-boto3-kms (==1.17.6.0)", "mypy-boto3-lakeformation (==1.17.6.0)", "mypy-boto3-lambda (==1.17.6.0)", "mypy-boto3-lex-models (==1.17.6.0)", "mypy-boto3-lex-runtime (==1.17.6.0)", "mypy-boto3-lexv2-models (==1.17.6.0)", "mypy-boto3-lexv2-runtime (==1.17.6.0)", "mypy-boto3-license-manager (==1.17.6.0)", "mypy-boto3-lightsail (==1.17.6.0)", "mypy-boto3-location (==1.17.6.0)", "mypy-boto3-logs (==1.17.6.0)", "mypy-boto3-lookoutvision (==1.17.6.0)", "mypy-boto3-machinelearning (==1.17.6.0)", "mypy-boto3-macie (==1.17.6.0)", "mypy-boto3-macie2 (==1.17.6.0)", "mypy-boto3-managedblockchain (==1.17.6.0)", "mypy-boto3-marketplace-catalog (==1.17.6.0)", "mypy-boto3-marketplace-entitlement (==1.17.6.0)", "mypy-boto3-marketplacecommerceanalytics (==1.17.6.0)", "mypy-boto3-mediaconnect (==1.17.6.0)", "mypy-boto3-mediaconvert (==1.17.6.0)", "mypy-boto3-medialive (==1.17.6.0)", "mypy-boto3-mediapackage (==1.17.6.0)", "mypy-boto3-mediapackage-vod (==1.17.6.0)", "mypy-boto3-mediastore (==1.17.6.0)", "mypy-boto3-mediastore-data (==1.17.6.0)", "mypy-boto3-mediatailor (==1.17.6.0)", "mypy-boto3-meteringmarketplace (==1.17.6.0)", "mypy-boto3-mgh (==1.17.6.0)", "mypy-boto3-migrationhub-config (==1.17.6.0)", "mypy-boto3-mobile (==1.17.6.0)", "mypy-boto3-mq (==1.17.6.0)", "mypy-boto3-mturk (==1.17.6.0)", "mypy-boto3-mwaa (==1.17.6.0)", "mypy-boto3-neptune (==1.17.6.0)", "mypy-boto3-network-firewall (==1.17.6.0)", "mypy-boto3-networkmanager (==1.17.6.0)", "mypy-boto3-opsworks (==1.17.6.0)", "mypy-boto3-opsworkscm (==1.17.6.0)", "mypy-boto3-organizations (==1.17.6.0)", "mypy-boto3-outposts (==1.17.6.0)", "mypy-boto3-personalize (==1.17.6.0)", "mypy-boto3-personalize-events (==1.17.6.0)", "mypy-boto3-personalize-runtime (==1.17.6.0)", "mypy-boto3-pi (==1.17.6.0)", "mypy-boto3-pinpoint (==1.17.6.0)", "mypy-boto3-pinpoint-email (==1.17.6.0)", "mypy-boto3-pinpoint-sms-voice (==1.17.6.0)", "mypy-boto3-polly (==1.17.6.0)", "mypy-boto3-pricing (==1.17.6.0)", "mypy-boto3-qldb (==1.17.6.0)", "mypy-boto3-qldb-session (==1.17.6.0)", "mypy-boto3-quicksight (==1.17.6.0)", "mypy-boto3-ram (==1.17.6.0)", "mypy-boto3-rds (==1.17.6.0)", "mypy-boto3-rds-data (==1.17.6.0)", "mypy-boto3-redshift (==1.17.6.0)", "mypy-boto3-redshift-data (==1.17.6.0)", "mypy-boto3-rekognition (==1.17.6.0)", "mypy-boto3-resource-groups (==1.17.6.0)", "mypy-boto3-resourcegroupstaggingapi (==1.17.6.0)", "mypy-boto3-robomaker (==1.17.6.0)", "mypy-boto3-route53 (==1.17.6.0)", "mypy-boto3-route53domains (==1.17.6.0)", "mypy-boto3-route53resolver (==1.17.6.0)", "mypy-boto3-s3 (==1.17.6.0)", "mypy-boto3-s3control (==1.17.6.0)", "mypy-boto3-s3outposts (==1.17.6.0)", "mypy-boto3-sagemaker (==1.17.6.0)", "mypy-boto3-sagemaker-a2i-runtime (==1.17.6.0)", "mypy-boto3-sagemaker-edge (==1.17.6.0)", "mypy-boto3-sagemaker-featurestore-runtime (==1.17.6.0)", "mypy-boto3-sagemaker-runtime (==1.17.6.0)", "mypy-boto3-savingsplans (==1.17.6.0)", "mypy-boto3-schemas (==1.17.6.0)", "mypy-boto3-sdb (==1.17.6.0)", "mypy-boto3-secretsmanager (==1.17.6.0)", "mypy-boto3-securityhub (==1.17.6.0)", "mypy-boto3-serverlessrepo (==1.17.6.0)", "mypy-boto3-service-quotas (==1.17.6.0)", "mypy-boto3-servicecatalog (==1.17.6.0)", "mypy-boto3-servicecatalog-appregistry (==1.17.6.0)", "mypy-boto3-servicediscovery (==1.17.6.0)", "mypy-boto3-ses (==1.17.6.0)", "mypy-boto3-sesv2 (==1.17.6.0)", "mypy-boto3-shield (==1.17.6.0)", "mypy-boto3-signer (==1.17.6.0)", "mypy-boto3-sms (==1.17.6.0)", "mypy-boto3-sms-voice (==1.17.6.0)", "mypy-boto3-snowball (==1.17.6.0)", "mypy-boto3-sns (==1.17.6.0)", "mypy-boto3-sqs (==1.17.6.0)", "mypy-boto3-ssm (==1.17.6.0)", "mypy-boto3-sso (==1.17.6.0)", "mypy-boto3-sso-admin (==1.17.6.0)", "mypy-boto3-sso-oidc (==1.17.6.0)", "mypy-boto3-stepfunctions (==1.17.6.0)", "mypy-boto3-storagegateway (==1.17.6.0)", "mypy-boto3-sts (==1.17.6.0)", "mypy-boto3-support (==1.17.6.0)", "mypy-boto3-swf (==1.17.6.0)", "mypy-boto3-synthetics (==1.17.6.0)", "mypy-boto3-textract (==1.17.6.0)", "mypy-boto3-timestream-query (==1.17.6.0)", "mypy-boto3-timestream-write (==1.17.6.0)", "mypy-boto3-transcribe (==1.17.6.0)", "mypy-boto3-transfer (==1.17.6.0)", "mypy-boto3-translate (==1.17.6.0)", "mypy-boto3-waf (==1.17.6.0)", "mypy-boto3-waf-regional (==1.17.6.0)", "mypy-boto3-wafv2 (==1.17.6.0)", "mypy-boto3-wellarchitected (==1.17.6.0)", "mypy-boto3-workdocs (==1.17.6.0)", "mypy-boto3-worklink (==1.17.6.0)", "mypy-boto3-workmail (==1.17.6.0)", "mypy-boto3-workmailmessageflow (==1.17.6.0)", "mypy-boto3-workspaces (==1.17.6.0)", "mypy-boto3-xray (==1.17.6.0)"]
+amp = ["mypy-boto3-amp (==1.17.6.0)"]
+amplify = ["mypy-boto3-amplify (==1.17.6.0)"]
+amplifybackend = ["mypy-boto3-amplifybackend (==1.17.6.0)"]
+apigateway = ["mypy-boto3-apigateway (==1.17.6.0)"]
+apigatewaymanagementapi = ["mypy-boto3-apigatewaymanagementapi (==1.17.6.0)"]
+apigatewayv2 = ["mypy-boto3-apigatewayv2 (==1.17.6.0)"]
+appconfig = ["mypy-boto3-appconfig (==1.17.6.0)"]
+appflow = ["mypy-boto3-appflow (==1.17.6.0)"]
+appintegrations = ["mypy-boto3-appintegrations (==1.17.6.0)"]
+application-autoscaling = ["mypy-boto3-application-autoscaling (==1.17.6.0)"]
+application-insights = ["mypy-boto3-application-insights (==1.17.6.0)"]
+appmesh = ["mypy-boto3-appmesh (==1.17.6.0)"]
+appstream = ["mypy-boto3-appstream (==1.17.6.0)"]
+appsync = ["mypy-boto3-appsync (==1.17.6.0)"]
+athena = ["mypy-boto3-athena (==1.17.6.0)"]
+auditmanager = ["mypy-boto3-auditmanager (==1.17.6.0)"]
+autoscaling = ["mypy-boto3-autoscaling (==1.17.6.0)"]
+autoscaling-plans = ["mypy-boto3-autoscaling-plans (==1.17.6.0)"]
+backup = ["mypy-boto3-backup (==1.17.6.0)"]
+batch = ["mypy-boto3-batch (==1.17.6.0)"]
+braket = ["mypy-boto3-braket (==1.17.6.0)"]
+budgets = ["mypy-boto3-budgets (==1.17.6.0)"]
+ce = ["mypy-boto3-ce (==1.17.6.0)"]
+chime = ["mypy-boto3-chime (==1.17.6.0)"]
+cloud9 = ["mypy-boto3-cloud9 (==1.17.6.0)"]
+clouddirectory = ["mypy-boto3-clouddirectory (==1.17.6.0)"]
+cloudformation = ["mypy-boto3-cloudformation (==1.17.6.0)"]
+cloudfront = ["mypy-boto3-cloudfront (==1.17.6.0)"]
+cloudhsm = ["mypy-boto3-cloudhsm (==1.17.6.0)"]
+cloudhsmv2 = ["mypy-boto3-cloudhsmv2 (==1.17.6.0)"]
+cloudsearch = ["mypy-boto3-cloudsearch (==1.17.6.0)"]
+cloudsearchdomain = ["mypy-boto3-cloudsearchdomain (==1.17.6.0)"]
+cloudtrail = ["mypy-boto3-cloudtrail (==1.17.6.0)"]
+cloudwatch = ["mypy-boto3-cloudwatch (==1.17.6.0)"]
+codeartifact = ["mypy-boto3-codeartifact (==1.17.6.0)"]
+codebuild = ["mypy-boto3-codebuild (==1.17.6.0)"]
+codecommit = ["mypy-boto3-codecommit (==1.17.6.0)"]
+codedeploy = ["mypy-boto3-codedeploy (==1.17.6.0)"]
+codeguru-reviewer = ["mypy-boto3-codeguru-reviewer (==1.17.6.0)"]
+codeguruprofiler = ["mypy-boto3-codeguruprofiler (==1.17.6.0)"]
+codepipeline = ["mypy-boto3-codepipeline (==1.17.6.0)"]
+codestar = ["mypy-boto3-codestar (==1.17.6.0)"]
+codestar-connections = ["mypy-boto3-codestar-connections (==1.17.6.0)"]
+codestar-notifications = ["mypy-boto3-codestar-notifications (==1.17.6.0)"]
+cognito-identity = ["mypy-boto3-cognito-identity (==1.17.6.0)"]
+cognito-idp = ["mypy-boto3-cognito-idp (==1.17.6.0)"]
+cognito-sync = ["mypy-boto3-cognito-sync (==1.17.6.0)"]
+comprehend = ["mypy-boto3-comprehend (==1.17.6.0)"]
+comprehendmedical = ["mypy-boto3-comprehendmedical (==1.17.6.0)"]
+compute-optimizer = ["mypy-boto3-compute-optimizer (==1.17.6.0)"]
+config = ["mypy-boto3-config (==1.17.6.0)"]
+connect = ["mypy-boto3-connect (==1.17.6.0)"]
+connect-contact-lens = ["mypy-boto3-connect-contact-lens (==1.17.6.0)"]
+connectparticipant = ["mypy-boto3-connectparticipant (==1.17.6.0)"]
+cur = ["mypy-boto3-cur (==1.17.6.0)"]
+customer-profiles = ["mypy-boto3-customer-profiles (==1.17.6.0)"]
+databrew = ["mypy-boto3-databrew (==1.17.6.0)"]
+dataexchange = ["mypy-boto3-dataexchange (==1.17.6.0)"]
+datapipeline = ["mypy-boto3-datapipeline (==1.17.6.0)"]
+datasync = ["mypy-boto3-datasync (==1.17.6.0)"]
+dax = ["mypy-boto3-dax (==1.17.6.0)"]
+detective = ["mypy-boto3-detective (==1.17.6.0)"]
+devicefarm = ["mypy-boto3-devicefarm (==1.17.6.0)"]
+devops-guru = ["mypy-boto3-devops-guru (==1.17.6.0)"]
+directconnect = ["mypy-boto3-directconnect (==1.17.6.0)"]
+discovery = ["mypy-boto3-discovery (==1.17.6.0)"]
+dlm = ["mypy-boto3-dlm (==1.17.6.0)"]
+dms = ["mypy-boto3-dms (==1.17.6.0)"]
+docdb = ["mypy-boto3-docdb (==1.17.6.0)"]
+ds = ["mypy-boto3-ds (==1.17.6.0)"]
+dynamodb = ["mypy-boto3-dynamodb (==1.17.6.0)"]
+dynamodbstreams = ["mypy-boto3-dynamodbstreams (==1.17.6.0)"]
+ebs = ["mypy-boto3-ebs (==1.17.6.0)"]
+ec2 = ["mypy-boto3-ec2 (==1.17.6.0)"]
+ec2-instance-connect = ["mypy-boto3-ec2-instance-connect (==1.17.6.0)"]
+ecr = ["mypy-boto3-ecr (==1.17.6.0)"]
+ecr-public = ["mypy-boto3-ecr-public (==1.17.6.0)"]
+ecs = ["mypy-boto3-ecs (==1.17.6.0)"]
+efs = ["mypy-boto3-efs (==1.17.6.0)"]
+eks = ["mypy-boto3-eks (==1.17.6.0)"]
+elastic-inference = ["mypy-boto3-elastic-inference (==1.17.6.0)"]
+elasticache = ["mypy-boto3-elasticache (==1.17.6.0)"]
+elasticbeanstalk = ["mypy-boto3-elasticbeanstalk (==1.17.6.0)"]
+elastictranscoder = ["mypy-boto3-elastictranscoder (==1.17.6.0)"]
+elb = ["mypy-boto3-elb (==1.17.6.0)"]
+elbv2 = ["mypy-boto3-elbv2 (==1.17.6.0)"]
+emr = ["mypy-boto3-emr (==1.17.6.0)"]
+emr-containers = ["mypy-boto3-emr-containers (==1.17.6.0)"]
+es = ["mypy-boto3-es (==1.17.6.0)"]
+essential = ["mypy-boto3-cloudformation (==1.17.6.0)", "mypy-boto3-dynamodb (==1.17.6.0)", "mypy-boto3-ec2 (==1.17.6.0)", "mypy-boto3-lambda (==1.17.6.0)", "mypy-boto3-rds (==1.17.6.0)", "mypy-boto3-s3 (==1.17.6.0)", "mypy-boto3-sqs (==1.17.6.0)"]
+events = ["mypy-boto3-events (==1.17.6.0)"]
+firehose = ["mypy-boto3-firehose (==1.17.6.0)"]
+fms = ["mypy-boto3-fms (==1.17.6.0)"]
+forecast = ["mypy-boto3-forecast (==1.17.6.0)"]
+forecastquery = ["mypy-boto3-forecastquery (==1.17.6.0)"]
+frauddetector = ["mypy-boto3-frauddetector (==1.17.6.0)"]
+fsx = ["mypy-boto3-fsx (==1.17.6.0)"]
+gamelift = ["mypy-boto3-gamelift (==1.17.6.0)"]
+glacier = ["mypy-boto3-glacier (==1.17.6.0)"]
+globalaccelerator = ["mypy-boto3-globalaccelerator (==1.17.6.0)"]
+glue = ["mypy-boto3-glue (==1.17.6.0)"]
+greengrass = ["mypy-boto3-greengrass (==1.17.6.0)"]
+greengrassv2 = ["mypy-boto3-greengrassv2 (==1.17.6.0)"]
+groundstation = ["mypy-boto3-groundstation (==1.17.6.0)"]
+guardduty = ["mypy-boto3-guardduty (==1.17.6.0)"]
+health = ["mypy-boto3-health (==1.17.6.0)"]
+healthlake = ["mypy-boto3-healthlake (==1.17.6.0)"]
+honeycode = ["mypy-boto3-honeycode (==1.17.6.0)"]
+iam = ["mypy-boto3-iam (==1.17.6.0)"]
+identitystore = ["mypy-boto3-identitystore (==1.17.6.0)"]
+imagebuilder = ["mypy-boto3-imagebuilder (==1.17.6.0)"]
+importexport = ["mypy-boto3-importexport (==1.17.6.0)"]
+inspector = ["mypy-boto3-inspector (==1.17.6.0)"]
+iot = ["mypy-boto3-iot (==1.17.6.0)"]
+iot-data = ["mypy-boto3-iot-data (==1.17.6.0)"]
+iot-jobs-data = ["mypy-boto3-iot-jobs-data (==1.17.6.0)"]
+iot1click-devices = ["mypy-boto3-iot1click-devices (==1.17.6.0)"]
+iot1click-projects = ["mypy-boto3-iot1click-projects (==1.17.6.0)"]
+iotanalytics = ["mypy-boto3-iotanalytics (==1.17.6.0)"]
+iotdeviceadvisor = ["mypy-boto3-iotdeviceadvisor (==1.17.6.0)"]
+iotevents = ["mypy-boto3-iotevents (==1.17.6.0)"]
+iotevents-data = ["mypy-boto3-iotevents-data (==1.17.6.0)"]
+iotfleethub = ["mypy-boto3-iotfleethub (==1.17.6.0)"]
+iotsecuretunneling = ["mypy-boto3-iotsecuretunneling (==1.17.6.0)"]
+iotsitewise = ["mypy-boto3-iotsitewise (==1.17.6.0)"]
+iotthingsgraph = ["mypy-boto3-iotthingsgraph (==1.17.6.0)"]
+iotwireless = ["mypy-boto3-iotwireless (==1.17.6.0)"]
+ivs = ["mypy-boto3-ivs (==1.17.6.0)"]
+kafka = ["mypy-boto3-kafka (==1.17.6.0)"]
+kendra = ["mypy-boto3-kendra (==1.17.6.0)"]
+kinesis = ["mypy-boto3-kinesis (==1.17.6.0)"]
+kinesis-video-archived-media = ["mypy-boto3-kinesis-video-archived-media (==1.17.6.0)"]
+kinesis-video-media = ["mypy-boto3-kinesis-video-media (==1.17.6.0)"]
+kinesis-video-signaling = ["mypy-boto3-kinesis-video-signaling (==1.17.6.0)"]
+kinesisanalytics = ["mypy-boto3-kinesisanalytics (==1.17.6.0)"]
+kinesisanalyticsv2 = ["mypy-boto3-kinesisanalyticsv2 (==1.17.6.0)"]
+kinesisvideo = ["mypy-boto3-kinesisvideo (==1.17.6.0)"]
+kms = ["mypy-boto3-kms (==1.17.6.0)"]
+lakeformation = ["mypy-boto3-lakeformation (==1.17.6.0)"]
+lambda = ["mypy-boto3-lambda (==1.17.6.0)"]
+lex-models = ["mypy-boto3-lex-models (==1.17.6.0)"]
+lex-runtime = ["mypy-boto3-lex-runtime (==1.17.6.0)"]
+lexv2-models = ["mypy-boto3-lexv2-models (==1.17.6.0)"]
+lexv2-runtime = ["mypy-boto3-lexv2-runtime (==1.17.6.0)"]
+license-manager = ["mypy-boto3-license-manager (==1.17.6.0)"]
+lightsail = ["mypy-boto3-lightsail (==1.17.6.0)"]
+location = ["mypy-boto3-location (==1.17.6.0)"]
+logs = ["mypy-boto3-logs (==1.17.6.0)"]
+lookoutvision = ["mypy-boto3-lookoutvision (==1.17.6.0)"]
+machinelearning = ["mypy-boto3-machinelearning (==1.17.6.0)"]
+macie = ["mypy-boto3-macie (==1.17.6.0)"]
+macie2 = ["mypy-boto3-macie2 (==1.17.6.0)"]
+managedblockchain = ["mypy-boto3-managedblockchain (==1.17.6.0)"]
+marketplace-catalog = ["mypy-boto3-marketplace-catalog (==1.17.6.0)"]
+marketplace-entitlement = ["mypy-boto3-marketplace-entitlement (==1.17.6.0)"]
+marketplacecommerceanalytics = ["mypy-boto3-marketplacecommerceanalytics (==1.17.6.0)"]
+mediaconnect = ["mypy-boto3-mediaconnect (==1.17.6.0)"]
+mediaconvert = ["mypy-boto3-mediaconvert (==1.17.6.0)"]
+medialive = ["mypy-boto3-medialive (==1.17.6.0)"]
+mediapackage = ["mypy-boto3-mediapackage (==1.17.6.0)"]
+mediapackage-vod = ["mypy-boto3-mediapackage-vod (==1.17.6.0)"]
+mediastore = ["mypy-boto3-mediastore (==1.17.6.0)"]
+mediastore-data = ["mypy-boto3-mediastore-data (==1.17.6.0)"]
+mediatailor = ["mypy-boto3-mediatailor (==1.17.6.0)"]
+meteringmarketplace = ["mypy-boto3-meteringmarketplace (==1.17.6.0)"]
+mgh = ["mypy-boto3-mgh (==1.17.6.0)"]
+migrationhub-config = ["mypy-boto3-migrationhub-config (==1.17.6.0)"]
+mobile = ["mypy-boto3-mobile (==1.17.6.0)"]
+mq = ["mypy-boto3-mq (==1.17.6.0)"]
+mturk = ["mypy-boto3-mturk (==1.17.6.0)"]
+mwaa = ["mypy-boto3-mwaa (==1.17.6.0)"]
+neptune = ["mypy-boto3-neptune (==1.17.6.0)"]
+network-firewall = ["mypy-boto3-network-firewall (==1.17.6.0)"]
+networkmanager = ["mypy-boto3-networkmanager (==1.17.6.0)"]
+opsworks = ["mypy-boto3-opsworks (==1.17.6.0)"]
+opsworkscm = ["mypy-boto3-opsworkscm (==1.17.6.0)"]
+organizations = ["mypy-boto3-organizations (==1.17.6.0)"]
+outposts = ["mypy-boto3-outposts (==1.17.6.0)"]
+personalize = ["mypy-boto3-personalize (==1.17.6.0)"]
+personalize-events = ["mypy-boto3-personalize-events (==1.17.6.0)"]
+personalize-runtime = ["mypy-boto3-personalize-runtime (==1.17.6.0)"]
+pi = ["mypy-boto3-pi (==1.17.6.0)"]
+pinpoint = ["mypy-boto3-pinpoint (==1.17.6.0)"]
+pinpoint-email = ["mypy-boto3-pinpoint-email (==1.17.6.0)"]
+pinpoint-sms-voice = ["mypy-boto3-pinpoint-sms-voice (==1.17.6.0)"]
+polly = ["mypy-boto3-polly (==1.17.6.0)"]
+pricing = ["mypy-boto3-pricing (==1.17.6.0)"]
+qldb = ["mypy-boto3-qldb (==1.17.6.0)"]
+qldb-session = ["mypy-boto3-qldb-session (==1.17.6.0)"]
+quicksight = ["mypy-boto3-quicksight (==1.17.6.0)"]
+ram = ["mypy-boto3-ram (==1.17.6.0)"]
+rds = ["mypy-boto3-rds (==1.17.6.0)"]
+rds-data = ["mypy-boto3-rds-data (==1.17.6.0)"]
+redshift = ["mypy-boto3-redshift (==1.17.6.0)"]
+redshift-data = ["mypy-boto3-redshift-data (==1.17.6.0)"]
+rekognition = ["mypy-boto3-rekognition (==1.17.6.0)"]
+resource-groups = ["mypy-boto3-resource-groups (==1.17.6.0)"]
+resourcegroupstaggingapi = ["mypy-boto3-resourcegroupstaggingapi (==1.17.6.0)"]
+robomaker = ["mypy-boto3-robomaker (==1.17.6.0)"]
+route53 = ["mypy-boto3-route53 (==1.17.6.0)"]
+route53domains = ["mypy-boto3-route53domains (==1.17.6.0)"]
+route53resolver = ["mypy-boto3-route53resolver (==1.17.6.0)"]
+s3 = ["mypy-boto3-s3 (==1.17.6.0)"]
+s3control = ["mypy-boto3-s3control (==1.17.6.0)"]
+s3outposts = ["mypy-boto3-s3outposts (==1.17.6.0)"]
+sagemaker = ["mypy-boto3-sagemaker (==1.17.6.0)"]
+sagemaker-a2i-runtime = ["mypy-boto3-sagemaker-a2i-runtime (==1.17.6.0)"]
+sagemaker-edge = ["mypy-boto3-sagemaker-edge (==1.17.6.0)"]
+sagemaker-featurestore-runtime = ["mypy-boto3-sagemaker-featurestore-runtime (==1.17.6.0)"]
+sagemaker-runtime = ["mypy-boto3-sagemaker-runtime (==1.17.6.0)"]
+savingsplans = ["mypy-boto3-savingsplans (==1.17.6.0)"]
+schemas = ["mypy-boto3-schemas (==1.17.6.0)"]
+sdb = ["mypy-boto3-sdb (==1.17.6.0)"]
+secretsmanager = ["mypy-boto3-secretsmanager (==1.17.6.0)"]
+securityhub = ["mypy-boto3-securityhub (==1.17.6.0)"]
+serverlessrepo = ["mypy-boto3-serverlessrepo (==1.17.6.0)"]
+service-quotas = ["mypy-boto3-service-quotas (==1.17.6.0)"]
+servicecatalog = ["mypy-boto3-servicecatalog (==1.17.6.0)"]
+servicecatalog-appregistry = ["mypy-boto3-servicecatalog-appregistry (==1.17.6.0)"]
+servicediscovery = ["mypy-boto3-servicediscovery (==1.17.6.0)"]
+ses = ["mypy-boto3-ses (==1.17.6.0)"]
+sesv2 = ["mypy-boto3-sesv2 (==1.17.6.0)"]
+shield = ["mypy-boto3-shield (==1.17.6.0)"]
+signer = ["mypy-boto3-signer (==1.17.6.0)"]
+sms = ["mypy-boto3-sms (==1.17.6.0)"]
+sms-voice = ["mypy-boto3-sms-voice (==1.17.6.0)"]
+snowball = ["mypy-boto3-snowball (==1.17.6.0)"]
+sns = ["mypy-boto3-sns (==1.17.6.0)"]
+sqs = ["mypy-boto3-sqs (==1.17.6.0)"]
+ssm = ["mypy-boto3-ssm (==1.17.6.0)"]
+sso = ["mypy-boto3-sso (==1.17.6.0)"]
+sso-admin = ["mypy-boto3-sso-admin (==1.17.6.0)"]
+sso-oidc = ["mypy-boto3-sso-oidc (==1.17.6.0)"]
+stepfunctions = ["mypy-boto3-stepfunctions (==1.17.6.0)"]
+storagegateway = ["mypy-boto3-storagegateway (==1.17.6.0)"]
+sts = ["mypy-boto3-sts (==1.17.6.0)"]
+support = ["mypy-boto3-support (==1.17.6.0)"]
+swf = ["mypy-boto3-swf (==1.17.6.0)"]
+synthetics = ["mypy-boto3-synthetics (==1.17.6.0)"]
+textract = ["mypy-boto3-textract (==1.17.6.0)"]
+timestream-query = ["mypy-boto3-timestream-query (==1.17.6.0)"]
+timestream-write = ["mypy-boto3-timestream-write (==1.17.6.0)"]
+transcribe = ["mypy-boto3-transcribe (==1.17.6.0)"]
+transfer = ["mypy-boto3-transfer (==1.17.6.0)"]
+translate = ["mypy-boto3-translate (==1.17.6.0)"]
+waf = ["mypy-boto3-waf (==1.17.6.0)"]
+waf-regional = ["mypy-boto3-waf-regional (==1.17.6.0)"]
+wafv2 = ["mypy-boto3-wafv2 (==1.17.6.0)"]
+wellarchitected = ["mypy-boto3-wellarchitected (==1.17.6.0)"]
+workdocs = ["mypy-boto3-workdocs (==1.17.6.0)"]
+worklink = ["mypy-boto3-worklink (==1.17.6.0)"]
+workmail = ["mypy-boto3-workmail (==1.17.6.0)"]
+workmailmessageflow = ["mypy-boto3-workmailmessageflow (==1.17.6.0)"]
+workspaces = ["mypy-boto3-workspaces (==1.17.6.0)"]
+xray = ["mypy-boto3-xray (==1.17.6.0)"]
 
 [[package]]
 name = "botocore"
-version = "1.20.5"
+version = "1.20.6"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = true
@@ -1286,7 +1334,7 @@ urllib3 = ">=1.25.4,<1.27"
 
 [[package]]
 name = "cattrs"
-version = "1.2.0"
+version = "1.1.2"
 description = "Composable complex class support for attrs."
 category = "main"
 optional = true
@@ -1340,14 +1388,14 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "constructs"
-version = "3.2.11"
+version = "3.3.18"
 description = "A programming model for composable configuration"
 category = "main"
 optional = true
 python-versions = ">=3.6"
 
 [package.dependencies]
-jsii = ">=1.14.0,<2.0.0"
+jsii = ">=1.20.0,<2.0.0"
 publication = ">=0.0.3"
 
 [[package]]
@@ -1535,15 +1583,15 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "jsii"
-version = "1.14.0"
+version = "1.20.1"
 description = "Python client for jsii runtime"
 category = "main"
 optional = true
-python-versions = ">=3.6"
+python-versions = "~=3.6"
 
 [package.dependencies]
 attrs = ">=20.1,<21.0"
-cattrs = ">=1.0,<2.0"
+cattrs = {version = ">=1.1.0,<1.2.0", markers = "python_version >= \"3.7\""}
 python-dateutil = "*"
 typing-extensions = ">=3.7,<4.0"
 
@@ -1634,48 +1682,48 @@ dmypy = ["psutil (>=4.0)"]
 
 [[package]]
 name = "mypy-boto3-batch"
-version = "1.17.5.0"
-description = "Type annotations for boto3.Batch 1.17.5 service, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3.Batch 1.17.6 service, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mypy-boto3-dynamodb"
-version = "1.17.5.0"
-description = "Type annotations for boto3.DynamoDB 1.17.5 service, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3.DynamoDB 1.17.6 service, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mypy-boto3-lambda"
-version = "1.17.5.0"
-description = "Type annotations for boto3.Lambda 1.17.5 service, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3.Lambda 1.17.6 service, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mypy-boto3-s3"
-version = "1.17.5.0"
-description = "Type annotations for boto3.S3 1.17.5 service, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3.S3 1.17.6 service, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mypy-boto3-ssm"
-version = "1.17.5.0"
-description = "Type annotations for boto3.SSM 1.17.5 service, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3.SSM 1.17.6 service, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
 [[package]]
 name = "mypy-boto3-stepfunctions"
-version = "1.17.5.0"
-description = "Type annotations for boto3.SFN 1.17.5 service, generated by mypy-boto3-buider 4.4.0"
+version = "1.17.6.0"
+description = "Type annotations for boto3.SFN 1.17.6 service, generated by mypy-boto3-buider 4.4.0"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
@@ -1775,7 +1823,7 @@ virtualenv = ">=20.0.8"
 
 [[package]]
 name = "prompt-toolkit"
-version = "3.0.14"
+version = "3.0.16"
 description = "Library for building powerful interactive command lines in Python"
 category = "dev"
 optional = false
@@ -2177,7 +2225,7 @@ datasets-endpoint = ["jsonschema", "pynamodb"]
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8,<3.9"
-content-hash = "8f805df07f515a9bed086b3f0148dffe410a068296729e26020ab1ce2dc94704"
+content-hash = "7c578d750e7802e792c8781bd487978d3f08ef93a98c19775d1bf7df416031af"
 
 [metadata.files]
 appdirs = [
@@ -2205,196 +2253,204 @@ attrs = [
     {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 "aws-cdk.assets" = [
-    {file = "aws-cdk.assets-1.71.0.tar.gz", hash = "sha256:9e7e3a9932a44427c8505c32580f4191bddbf479332e92345e319658a2cfcef3"},
-    {file = "aws_cdk.assets-1.71.0-py3-none-any.whl", hash = "sha256:6d1030a783a8a34071a9494ade03e7779a6c5a6acab3326eeb0795f2dbaa1266"},
+    {file = "aws-cdk.assets-1.89.0.tar.gz", hash = "sha256:a8fd89695d71a7ecb84ff1fe4aaa2154846c7e81c08a0f9e30d9c87cfd0b85a1"},
+    {file = "aws_cdk.assets-1.89.0-py3-none-any.whl", hash = "sha256:91549b13f1c61c578501c2e7ab2f413f55f7d874bc3d829fd73f0baa98d03fd1"},
 ]
 "aws-cdk.aws-apigateway" = [
-    {file = "aws-cdk.aws-apigateway-1.71.0.tar.gz", hash = "sha256:9163ffe65d7cfc6c442a01179db22f31ee85d3140c31d17b51ca26f131348e21"},
-    {file = "aws_cdk.aws_apigateway-1.71.0-py3-none-any.whl", hash = "sha256:92c0c4c8cb29dbb2d4ae5ff3c0405c6a33ee421be9ed16e18a7c2a2c8f6b0709"},
+    {file = "aws-cdk.aws-apigateway-1.89.0.tar.gz", hash = "sha256:1fec4aa2d3753e777c540592b7b1f66d00a14dbe8e0df93ce02cc3b7e45840e7"},
+    {file = "aws_cdk.aws_apigateway-1.89.0-py3-none-any.whl", hash = "sha256:b80f8fc7389d910d0d59a12476f1778b4021f452b4c74adeddbf4883ba055822"},
+]
+"aws-cdk.aws-apigatewayv2" = [
+    {file = "aws-cdk.aws-apigatewayv2-1.89.0.tar.gz", hash = "sha256:6962232b98892f6c51e9503e1291c8af0700c3b31590665d85be48252182f03c"},
+    {file = "aws_cdk.aws_apigatewayv2-1.89.0-py3-none-any.whl", hash = "sha256:d54851cc559d0c1dc5efe77263e04dd1fd06832d6a005c297c21dcb47db0d9ae"},
 ]
 "aws-cdk.aws-applicationautoscaling" = [
-    {file = "aws-cdk.aws-applicationautoscaling-1.71.0.tar.gz", hash = "sha256:19798f727e0b3ed8fef9b44b7b603b883af2294517adbea2e56246bcc3d3c380"},
-    {file = "aws_cdk.aws_applicationautoscaling-1.71.0-py3-none-any.whl", hash = "sha256:d1872ed2178ff7d9029fc3ee8eb1583e5b78d798f753741dbfbfa53174a78604"},
+    {file = "aws-cdk.aws-applicationautoscaling-1.89.0.tar.gz", hash = "sha256:84579975e9589b43be6fc512deea881211cc38c605fe579a27daf3c8191576a4"},
+    {file = "aws_cdk.aws_applicationautoscaling-1.89.0-py3-none-any.whl", hash = "sha256:1a874f2de572427dc08f8bea0be7ed54251ca1c911f4d2eb5a6e59ff5d39c4b4"},
 ]
 "aws-cdk.aws-autoscaling" = [
-    {file = "aws-cdk.aws-autoscaling-1.71.0.tar.gz", hash = "sha256:d3669e54f88904fd384107e27d6d9e4307b7eb70381165a88e9a2d76b61e76e2"},
-    {file = "aws_cdk.aws_autoscaling-1.71.0-py3-none-any.whl", hash = "sha256:c958b233460176b8cd5f102adf33dd2031eb9d31da60a709786f80533a3621e5"},
+    {file = "aws-cdk.aws-autoscaling-1.89.0.tar.gz", hash = "sha256:a3e169cf536e40d1a52d9f1c9b2eeabd891e340a2d7a69d8281158850a974684"},
+    {file = "aws_cdk.aws_autoscaling-1.89.0-py3-none-any.whl", hash = "sha256:def2949c6c0cc2c8a6fe7584bc88d7f8c8451710ddd2d44271cd740a68a9dab6"},
 ]
 "aws-cdk.aws-autoscaling-common" = [
-    {file = "aws-cdk.aws-autoscaling-common-1.71.0.tar.gz", hash = "sha256:91308b803499a0f9ea4076e49456312bb639793b4a69905b05dbd6d2501226a9"},
-    {file = "aws_cdk.aws_autoscaling_common-1.71.0-py3-none-any.whl", hash = "sha256:c47b0cf4aeed1b15c16e5ddca5e807211b2c4110bf46d5a3ed45ecf536942786"},
+    {file = "aws-cdk.aws-autoscaling-common-1.89.0.tar.gz", hash = "sha256:9353d14379a3a059de3914635d58205ccd82ea7d20bfef71d7020ad4449dac99"},
+    {file = "aws_cdk.aws_autoscaling_common-1.89.0-py3-none-any.whl", hash = "sha256:e943c9f9048a40003e04c3f3dba15a1805493d5ee3a7a672edfc2983fdbe012c"},
 ]
 "aws-cdk.aws-autoscaling-hooktargets" = [
-    {file = "aws-cdk.aws-autoscaling-hooktargets-1.71.0.tar.gz", hash = "sha256:0edf4103b24a4062d59c1fa7c2aa9f6b9afed69d507d33d4005377ded641d4a8"},
-    {file = "aws_cdk.aws_autoscaling_hooktargets-1.71.0-py3-none-any.whl", hash = "sha256:dd762bd1dfd4bc988faee1080a0b8f3332a345ae1c23b6fb1b349a22626031f8"},
+    {file = "aws-cdk.aws-autoscaling-hooktargets-1.89.0.tar.gz", hash = "sha256:693ef63a99c3652b12aa5cc8f8e282088d03edad581f3b094545942e43f375ae"},
+    {file = "aws_cdk.aws_autoscaling_hooktargets-1.89.0-py3-none-any.whl", hash = "sha256:603c3f3c9c7701fc376174638461a8e4d74cbbcdac9bb697129fedaa2a3c2cca"},
 ]
 "aws-cdk.aws-batch" = [
-    {file = "aws-cdk.aws-batch-1.71.0.tar.gz", hash = "sha256:11b521dcc27ce6b5ca707f71b7c0859b6b543d631a0b5f18a3690aa18c575d7d"},
-    {file = "aws_cdk.aws_batch-1.71.0-py3-none-any.whl", hash = "sha256:4f6c540fdba095512959d83ac2c20e094ce89e0ed0c0d4fefb937750e0a09cc0"},
+    {file = "aws-cdk.aws-batch-1.89.0.tar.gz", hash = "sha256:039f2a1650c10019d50a9f4f4f51fb358ccc3c7c02bfe4f76a1c2cfe45f4019b"},
+    {file = "aws_cdk.aws_batch-1.89.0-py3-none-any.whl", hash = "sha256:a9eb8c905d4a63eeea9c3320858056a21a145d3ae02ca0175bac5eda3c7e6ebc"},
 ]
 "aws-cdk.aws-certificatemanager" = [
-    {file = "aws-cdk.aws-certificatemanager-1.71.0.tar.gz", hash = "sha256:bd58b6f1c9c367dfc1cfb998784f338326017ab23558e7d4527e242566ddd7f8"},
-    {file = "aws_cdk.aws_certificatemanager-1.71.0-py3-none-any.whl", hash = "sha256:79146039ab65d09a5321af45befacc6abe373b0cf913ff7de19af0f245de3eae"},
+    {file = "aws-cdk.aws-certificatemanager-1.89.0.tar.gz", hash = "sha256:55442f1375bcb5d5e63083676690456c4397a1a73a23c2bb798493a60f1a5e75"},
+    {file = "aws_cdk.aws_certificatemanager-1.89.0-py3-none-any.whl", hash = "sha256:625e94cef0b69b74bf85f1ec2c5526e5fb7c644f465fc9a2f085d7b9796bdbbf"},
 ]
 "aws-cdk.aws-cloudformation" = [
-    {file = "aws-cdk.aws-cloudformation-1.71.0.tar.gz", hash = "sha256:4e378653c7e7738f6f7bbf250aa0e3add895e89507b772162fe32bd37ae02073"},
-    {file = "aws_cdk.aws_cloudformation-1.71.0-py3-none-any.whl", hash = "sha256:489d7649f13ce7ec3d0b4e303e8492db5d8136f7053c24ed5a79b445a13538d1"},
+    {file = "aws-cdk.aws-cloudformation-1.89.0.tar.gz", hash = "sha256:8c351dcf985a8633eeefe844760cfa56b17f4e9cbb8fbef16c19d387260a71b2"},
+    {file = "aws_cdk.aws_cloudformation-1.89.0-py3-none-any.whl", hash = "sha256:a13ac1d0ab92a579360eb225800ca8db8647d0d379e816a267fe9f2f5475f0de"},
 ]
 "aws-cdk.aws-cloudfront" = [
-    {file = "aws-cdk.aws-cloudfront-1.71.0.tar.gz", hash = "sha256:9665e536f0fc5950c7d66dcdcd4b35ad4befe124a2f1427a6fc0689a94bb8c1e"},
-    {file = "aws_cdk.aws_cloudfront-1.71.0-py3-none-any.whl", hash = "sha256:9d8bf95d1e3105a99fecdcccbd85d3a2c6ff82801ea0ea1ae6f1706eef6ff45e"},
+    {file = "aws-cdk.aws-cloudfront-1.89.0.tar.gz", hash = "sha256:6c3783e981d895221845c3629151f7d206884f7ea24aaafc3c43b0906cec2958"},
+    {file = "aws_cdk.aws_cloudfront-1.89.0-py3-none-any.whl", hash = "sha256:69d4a68f8dc6195f9efd8e8eb856ff8357f633adb4cc44e8267b00bbc6904d6f"},
 ]
 "aws-cdk.aws-cloudwatch" = [
-    {file = "aws-cdk.aws-cloudwatch-1.71.0.tar.gz", hash = "sha256:12187915abd5445ff7d3f221f28f06db3e376e41c11f2b39f5abc3136829d1a6"},
-    {file = "aws_cdk.aws_cloudwatch-1.71.0-py3-none-any.whl", hash = "sha256:5a0526c5c5d33d64279d283891e8489149fd628971671b4436b2978b14b1f00f"},
+    {file = "aws-cdk.aws-cloudwatch-1.89.0.tar.gz", hash = "sha256:9fe635771f400986bebabc891458a9b46be1622c092ef04a1a9ed273612e37e4"},
+    {file = "aws_cdk.aws_cloudwatch-1.89.0-py3-none-any.whl", hash = "sha256:ca7fe159a9c4d44fd3f99ed0841768799e9f2eac199239a37796df6e8a98c1e6"},
 ]
 "aws-cdk.aws-codebuild" = [
-    {file = "aws-cdk.aws-codebuild-1.71.0.tar.gz", hash = "sha256:b05e4a65eeb4b16b010976bbfeac6493e996815236e8caa6436e74ce9d4e7e0b"},
-    {file = "aws_cdk.aws_codebuild-1.71.0-py3-none-any.whl", hash = "sha256:83f9554a51efc41e580ac0c78d6fae42b75b699277b5003491237b0bb5b3b654"},
+    {file = "aws-cdk.aws-codebuild-1.89.0.tar.gz", hash = "sha256:84a5d832785484145e1af340e6b15c06fe648872cef59e3b4a29647202b5f7d7"},
+    {file = "aws_cdk.aws_codebuild-1.89.0-py3-none-any.whl", hash = "sha256:54f934efd99627d893cf0b7a6a606ba217af76832ada6e974a6d32b70943a5f8"},
 ]
 "aws-cdk.aws-codecommit" = [
-    {file = "aws-cdk.aws-codecommit-1.71.0.tar.gz", hash = "sha256:511f0e0ebc4d79876f509394d9909cad1e55fe1e45c4a34d081a860a39a3c03d"},
-    {file = "aws_cdk.aws_codecommit-1.71.0-py3-none-any.whl", hash = "sha256:4e80ff1138c0afb18df82bfdad82695f587a58ea20215b42b5b595618ee8a161"},
+    {file = "aws-cdk.aws-codecommit-1.89.0.tar.gz", hash = "sha256:5cfbb620c4184c94f466911ee4c8fc7b94033826beb2fd5971bad642fae379a4"},
+    {file = "aws_cdk.aws_codecommit-1.89.0-py3-none-any.whl", hash = "sha256:4c0ae22a1e7652665cf68da9cbdfadfabfda7249336b2a10515894192021a154"},
 ]
 "aws-cdk.aws-codeguruprofiler" = [
-    {file = "aws-cdk.aws-codeguruprofiler-1.71.0.tar.gz", hash = "sha256:9d86815bc97edf30ca8e1504d2544667248189a3c2ad7a5aa3bf6d78a6beda4d"},
-    {file = "aws_cdk.aws_codeguruprofiler-1.71.0-py3-none-any.whl", hash = "sha256:d7e6e105f1edb46cf5273acf23ce7f7bc98f26ffd4c3d1eef0488c8f9e26cbc3"},
+    {file = "aws-cdk.aws-codeguruprofiler-1.89.0.tar.gz", hash = "sha256:1228ff187a5637c93d44be27b3ebeadba3c2cf6bdddd678970aa1889523d4c9e"},
+    {file = "aws_cdk.aws_codeguruprofiler-1.89.0-py3-none-any.whl", hash = "sha256:7a5694e053fa3128262e1a735bb84fff866f0bce3deb9b2d9df72af91312eaaf"},
 ]
 "aws-cdk.aws-cognito" = [
-    {file = "aws-cdk.aws-cognito-1.71.0.tar.gz", hash = "sha256:17da38e34117ab8bb7286500022d4f03c559ba921f977653f6d357c553b687d0"},
-    {file = "aws_cdk.aws_cognito-1.71.0-py3-none-any.whl", hash = "sha256:b787c6de3ce9c8bfe9e70ecc4ed3a444aa94da8fa5afeaa0827a0ce37bd0521e"},
+    {file = "aws-cdk.aws-cognito-1.89.0.tar.gz", hash = "sha256:c135cc2c0bfd3f9ad4378a564aaab6083dea17e6c6019d3267c7127105240919"},
+    {file = "aws_cdk.aws_cognito-1.89.0-py3-none-any.whl", hash = "sha256:2e53b285a9bb7eb13830aed977c63b707d3c23bf66355b4b9c6ede01013bc8a7"},
+]
+"aws-cdk.aws-databrew" = [
+    {file = "aws-cdk.aws-databrew-1.89.0.tar.gz", hash = "sha256:f2e35d07c6fcce5de83272dd7794581f1563547743575603cd06837b8e7e247e"},
+    {file = "aws_cdk.aws_databrew-1.89.0-py3-none-any.whl", hash = "sha256:570deebf7472b59a12948ba6b2fc4fbbe70cb5e6f07f3cbf048d3261d4230ab1"},
 ]
 "aws-cdk.aws-dynamodb" = [
-    {file = "aws-cdk.aws-dynamodb-1.71.0.tar.gz", hash = "sha256:37c1a4f70a4f7eff254fe221cba271efa8e32420631bdf581f0f21e9516b80e9"},
-    {file = "aws_cdk.aws_dynamodb-1.71.0-py3-none-any.whl", hash = "sha256:9e94e04c75f878525094f4f31b36aa457417dd2131e4d8f038c1c8f0267e2df0"},
+    {file = "aws-cdk.aws-dynamodb-1.89.0.tar.gz", hash = "sha256:cb38cfbe140927b61633dfcb7c777952a451d1dc2d1f48efb89fcf9213576fd3"},
+    {file = "aws_cdk.aws_dynamodb-1.89.0-py3-none-any.whl", hash = "sha256:65f1e78a01c34e27abb7a89bd725b6bf2a2e66994011cb435046fe39c0886230"},
 ]
 "aws-cdk.aws-ec2" = [
-    {file = "aws-cdk.aws-ec2-1.71.0.tar.gz", hash = "sha256:804185ba4d4c81711607cb97ceea1b0c1e6e879af718e5a21247fa815831fa53"},
-    {file = "aws_cdk.aws_ec2-1.71.0-py3-none-any.whl", hash = "sha256:4d5aff77fcee9163219be35d989e32be2b722b26aba71404d1394e4bda7ad5ce"},
+    {file = "aws-cdk.aws-ec2-1.89.0.tar.gz", hash = "sha256:cbf8e10e3b97d834f8a66955755798d40c62907e5761da05c3e759eb6278e084"},
+    {file = "aws_cdk.aws_ec2-1.89.0-py3-none-any.whl", hash = "sha256:e21581eb7f0530f531e655c044d87a7bc412c2e3c0e7732fd1f8bfa4fe375f43"},
 ]
 "aws-cdk.aws-ecr" = [
-    {file = "aws-cdk.aws-ecr-1.71.0.tar.gz", hash = "sha256:b1480fdccc18c9dbd4cb120b2acd78da3badc1dd15288315843edde1fe1c7cee"},
-    {file = "aws_cdk.aws_ecr-1.71.0-py3-none-any.whl", hash = "sha256:262b24bb2b1a02c00fe147e3255853df268147572d529cf03638ef9b97995eab"},
+    {file = "aws-cdk.aws-ecr-1.89.0.tar.gz", hash = "sha256:dc4a419c0199acb525bc47ec97568283640f07508ac35ed07e247fc37946267e"},
+    {file = "aws_cdk.aws_ecr-1.89.0-py3-none-any.whl", hash = "sha256:7999bdea14c5c052da20b8f688c936f1ae6fe8e4e00ac8234be425bbbb8e2ad7"},
 ]
 "aws-cdk.aws-ecr-assets" = [
-    {file = "aws-cdk.aws-ecr-assets-1.71.0.tar.gz", hash = "sha256:f61a6388ef989b0b84b34cfeddd51cf376c9b5c9a2497fc380f147bfab1c4a3b"},
-    {file = "aws_cdk.aws_ecr_assets-1.71.0-py3-none-any.whl", hash = "sha256:ca6ded159db6a9bed5c18be2b4b7bd4e87e92320f3fff1a83bc34482c3ea47a4"},
+    {file = "aws-cdk.aws-ecr-assets-1.89.0.tar.gz", hash = "sha256:3abf42e912f549fb9e4b14f1199de19d17d898df7c5f1f539062a0412139f210"},
+    {file = "aws_cdk.aws_ecr_assets-1.89.0-py3-none-any.whl", hash = "sha256:9e61b85166fc6e2fed911d4304b0c8b6c5c9280ddd97d0ebd07ba5054316cc0e"},
 ]
 "aws-cdk.aws-ecs" = [
-    {file = "aws-cdk.aws-ecs-1.71.0.tar.gz", hash = "sha256:fad5490a31a9fc8a9883425d96f700db753e677270125e6aa6914c70d77cc17b"},
-    {file = "aws_cdk.aws_ecs-1.71.0-py3-none-any.whl", hash = "sha256:65254e5170f538f2f2a5d6c5ce68b6e962fbcf9fb0778863095bb5ad6f7c75fd"},
+    {file = "aws-cdk.aws-ecs-1.89.0.tar.gz", hash = "sha256:5f622203aac26d6d053b711ce2dfa9fa2185c8f2b585e175408ba8731ba31345"},
+    {file = "aws_cdk.aws_ecs-1.89.0-py3-none-any.whl", hash = "sha256:42f8e9ef4d5972334d5086221abb27c6786515debe844aa25868f8f3915db69a"},
 ]
 "aws-cdk.aws-efs" = [
-    {file = "aws-cdk.aws-efs-1.71.0.tar.gz", hash = "sha256:a69d40bd95cd345faed75203f1537dbfb79650e525b798e28a3569c508707029"},
-    {file = "aws_cdk.aws_efs-1.71.0-py3-none-any.whl", hash = "sha256:c970eef672bfe3518452fdb1dbf40586f8dd36decbcca0783ae7a75664a88509"},
+    {file = "aws-cdk.aws-efs-1.89.0.tar.gz", hash = "sha256:83918ae9e4f478914665266bc87258745d4cffd812080cfa13112781682b1aa1"},
+    {file = "aws_cdk.aws_efs-1.89.0-py3-none-any.whl", hash = "sha256:691ce506f1089cf766b4e1f965d69cb32313dde6145bf191b079e49e8c3bf68e"},
 ]
 "aws-cdk.aws-elasticloadbalancing" = [
-    {file = "aws-cdk.aws-elasticloadbalancing-1.71.0.tar.gz", hash = "sha256:c4539369889572ed55f189e51fc5a0fd02cfcf0bfa5d70fe2011341d4e8de220"},
-    {file = "aws_cdk.aws_elasticloadbalancing-1.71.0-py3-none-any.whl", hash = "sha256:f8954a5f59bc7485b4ce817ddce0993826765f44fdc21d6e3d0e50478f6b1057"},
+    {file = "aws-cdk.aws-elasticloadbalancing-1.89.0.tar.gz", hash = "sha256:406fac4856160379e6c790d76abcc132602c776bcc0bc09dca8c3949f288398f"},
+    {file = "aws_cdk.aws_elasticloadbalancing-1.89.0-py3-none-any.whl", hash = "sha256:508178aad65d972cb09740ce26bb530c8219302fe38c2b94ad9b6b169de419ec"},
 ]
 "aws-cdk.aws-elasticloadbalancingv2" = [
-    {file = "aws-cdk.aws-elasticloadbalancingv2-1.71.0.tar.gz", hash = "sha256:2b0264af23fe115edd55f8f5b20ade96d36807891210567fff9bc017d889f543"},
-    {file = "aws_cdk.aws_elasticloadbalancingv2-1.71.0-py3-none-any.whl", hash = "sha256:f399740e940de3eb2ce5b4a21f3b669e8b1e4a8ab1b51d3e530b078b30b541b2"},
+    {file = "aws-cdk.aws-elasticloadbalancingv2-1.89.0.tar.gz", hash = "sha256:8d6ff6da70d08e6f59cb88df7ba3b320b4c0aefe57ee25e278cca8426291558a"},
+    {file = "aws_cdk.aws_elasticloadbalancingv2-1.89.0-py3-none-any.whl", hash = "sha256:341b37424bb121788652ddc36bff0faeb8320a1a51842d8be7150deaa7acfaf2"},
 ]
 "aws-cdk.aws-events" = [
-    {file = "aws-cdk.aws-events-1.71.0.tar.gz", hash = "sha256:962c727a0f189fde9c61981d6e756d78a8ecced7b0689ce6a5c93d59553e9ff1"},
-    {file = "aws_cdk.aws_events-1.71.0-py3-none-any.whl", hash = "sha256:38d64ada489896bd195a6f0b30dc4a233123823d144114f5c8492e9befc42a12"},
+    {file = "aws-cdk.aws-events-1.89.0.tar.gz", hash = "sha256:d28342d044565211934fe907d6f4aaeb587f4d3a0db72d22595172296679c6de"},
+    {file = "aws_cdk.aws_events-1.89.0-py3-none-any.whl", hash = "sha256:4e7d1aef8f6cabbb190582500bc602cbbb2d317cb8efd00af568d237267e2538"},
 ]
 "aws-cdk.aws-glue" = [
-    {file = "aws-cdk.aws-glue-1.71.0.tar.gz", hash = "sha256:46212ed319ab931cf13ab6ab9ebdf8a550f9e4001c084137c4ec068135d37639"},
-    {file = "aws_cdk.aws_glue-1.71.0-py3-none-any.whl", hash = "sha256:528a805175ef5763f8d52983612e12e1e63d2f654f90886a7ad84006e380ddf4"},
+    {file = "aws-cdk.aws-glue-1.89.0.tar.gz", hash = "sha256:ad745857d19756de97107cbd6f3132e39a3f2ffb5abcea1706973ea822bc532e"},
+    {file = "aws_cdk.aws_glue-1.89.0-py3-none-any.whl", hash = "sha256:96e79f9db6d736960e2c0ef4f4e172587fac7a7015b73296846d9ae6dfc81fc8"},
 ]
 "aws-cdk.aws-iam" = [
-    {file = "aws-cdk.aws-iam-1.71.0.tar.gz", hash = "sha256:676b2f7c02aa370b711069dc6dfc188235c65db9044b3c9d4681fa83795b02f1"},
-    {file = "aws_cdk.aws_iam-1.71.0-py3-none-any.whl", hash = "sha256:6be9ab4738f342f55b5eff49a6486693f4a891ce7fb6132b73bfcc66eb20d009"},
+    {file = "aws-cdk.aws-iam-1.89.0.tar.gz", hash = "sha256:93d66a3f42d4681228dc2bf3d8f34b2d74a97d09b334fa435e543839c575b427"},
+    {file = "aws_cdk.aws_iam-1.89.0-py3-none-any.whl", hash = "sha256:978ffb264234930857b628142a4c64fe62341b239c03ea9d108ce18c81693742"},
 ]
 "aws-cdk.aws-kms" = [
-    {file = "aws-cdk.aws-kms-1.71.0.tar.gz", hash = "sha256:398be4ddb5aed6a77765a76542170cf364218c2e64a543f40541a0bde3dff505"},
-    {file = "aws_cdk.aws_kms-1.71.0-py3-none-any.whl", hash = "sha256:d6cc10498b672871d7eda807b9d23bc4cfecfe396db8efb8bc32f0386380154a"},
+    {file = "aws-cdk.aws-kms-1.89.0.tar.gz", hash = "sha256:9ef4a25261a2ca664e66fb4db24bf273e794d6f617e14240b9a6760280e42ea9"},
+    {file = "aws_cdk.aws_kms-1.89.0-py3-none-any.whl", hash = "sha256:4f22d3e128e355887cebd8ad50ea13291cf401d102ee30e06e7e8fcaf75c4f96"},
 ]
 "aws-cdk.aws-lambda" = [
-    {file = "aws-cdk.aws-lambda-1.71.0.tar.gz", hash = "sha256:a577c1877455d9fa6e4e11cd1a95dabd9b2bbdd2e560db699047a3a22bb5b8f1"},
-    {file = "aws_cdk.aws_lambda-1.71.0-py3-none-any.whl", hash = "sha256:118b8c54f2f78b3ea1eea1e199cbd7be2455b219d92d7882dc49de7b5e2d9ab5"},
+    {file = "aws-cdk.aws-lambda-1.89.0.tar.gz", hash = "sha256:7f8a3a5f5300f3bb28884356514b2f3d5d7a0c9149e0999b0c828fb31bbb1a49"},
+    {file = "aws_cdk.aws_lambda-1.89.0-py3-none-any.whl", hash = "sha256:38c9cabe112f2c27e05d0ee39e9d321727aa775287e055cf3dddd14cea60e9dd"},
 ]
 "aws-cdk.aws-logs" = [
-    {file = "aws-cdk.aws-logs-1.71.0.tar.gz", hash = "sha256:f347402654008438bca78580f796e85dbdf2521ac5c3224cd3fc364a7ed7cf9d"},
-    {file = "aws_cdk.aws_logs-1.71.0-py3-none-any.whl", hash = "sha256:a55d31c5eff40f1b07f62f1a52d063017e832d8bf4b838e0e6efba653ab65bff"},
+    {file = "aws-cdk.aws-logs-1.89.0.tar.gz", hash = "sha256:d07d4eae8f85ab1d72a04bea8183e579b05ea1dcf9ed07fadbde3e6e393ad9a6"},
+    {file = "aws_cdk.aws_logs-1.89.0-py3-none-any.whl", hash = "sha256:5dacd62fe065207d5aff5d0bf9bce6b1acc907a7b90f1a5d0c5c381a65dc551d"},
 ]
 "aws-cdk.aws-route53" = [
-    {file = "aws-cdk.aws-route53-1.71.0.tar.gz", hash = "sha256:3c9316f80d62202d555a3a6003c93bf2b7fb95a06a3fa8cc30754aae056916ff"},
-    {file = "aws_cdk.aws_route53-1.71.0-py3-none-any.whl", hash = "sha256:89f86b61c1f093cf3cdf73e2732ff390f951cc14fa6677e061a1585ca3068e06"},
+    {file = "aws-cdk.aws-route53-1.89.0.tar.gz", hash = "sha256:45af8c3c37ece8e72ab592db6eaab199a1e9bfb574f55322abb180866ec862f3"},
+    {file = "aws_cdk.aws_route53-1.89.0-py3-none-any.whl", hash = "sha256:6a59527af404d9bbdfcae5e645d70503561404934cc39564322a4f6a9a2d71e6"},
 ]
 "aws-cdk.aws-route53-targets" = [
-    {file = "aws-cdk.aws-route53-targets-1.71.0.tar.gz", hash = "sha256:0a67bcb14ca3a3ee87cc9aa57ef6a83304ec50d56b857dbab82461bd6b499c02"},
-    {file = "aws_cdk.aws_route53_targets-1.71.0-py3-none-any.whl", hash = "sha256:616639ce1fa73fab679ccf208b7748451f53eb9221f42e56f7a61652129c4e1b"},
+    {file = "aws-cdk.aws-route53-targets-1.89.0.tar.gz", hash = "sha256:9b22555730245c20333728f2c50ee56505f025387ea65642292476d14752a728"},
+    {file = "aws_cdk.aws_route53_targets-1.89.0-py3-none-any.whl", hash = "sha256:adbc95093a9e6b1c9921822740dc8a0f9046b713c6052a004b18813a377fd520"},
 ]
 "aws-cdk.aws-s3" = [
-    {file = "aws-cdk.aws-s3-1.71.0.tar.gz", hash = "sha256:d740ad6fb0713ce51f7db75166b83a589ca0dfc5ae159b708edd55d75d9cf98c"},
-    {file = "aws_cdk.aws_s3-1.71.0-py3-none-any.whl", hash = "sha256:75c06090407078c952dfb606e4cd8c89d725510f3810285c0003eb6737f5cc4e"},
+    {file = "aws-cdk.aws-s3-1.89.0.tar.gz", hash = "sha256:d16e102f4092f9b578bd88dc4238bc12dee15d1384b3e8b863e5ab4c20aa4c14"},
+    {file = "aws_cdk.aws_s3-1.89.0-py3-none-any.whl", hash = "sha256:dda308e5f285a4db4d7566875b782fd878a0e59a35192b7bb38f58f70fd78c39"},
 ]
 "aws-cdk.aws-s3-assets" = [
-    {file = "aws-cdk.aws-s3-assets-1.71.0.tar.gz", hash = "sha256:c8ee1ddb24f57d8092450532627658882555bc37ec11b03b57491cb0c8822156"},
-    {file = "aws_cdk.aws_s3_assets-1.71.0-py3-none-any.whl", hash = "sha256:6776dfc96eb520b07ba85adbc7213c943f9ea7c739f1831f9801e1dacb28090f"},
+    {file = "aws-cdk.aws-s3-assets-1.89.0.tar.gz", hash = "sha256:03a08a15ac25575f9e4b07feac9435bc15c7af7e35cca0aa82327f22be16f934"},
+    {file = "aws_cdk.aws_s3_assets-1.89.0-py3-none-any.whl", hash = "sha256:3db0b8145f834c2aee6be8b8fbeed30a6f681c003c7df43400c5030fe8500acc"},
 ]
 "aws-cdk.aws-sam" = [
-    {file = "aws-cdk.aws-sam-1.71.0.tar.gz", hash = "sha256:d348da733932e5c95585db2419fdc3329f767fa62cd2aa37cb72c6059c6a572d"},
-    {file = "aws_cdk.aws_sam-1.71.0-py3-none-any.whl", hash = "sha256:4485eceb535f875ce895e11d7159fc53d407cf287211784485e9c521a8e3573a"},
+    {file = "aws-cdk.aws-sam-1.89.0.tar.gz", hash = "sha256:08b8f16f1c8b7da33cf6c2521fa1eac5efe903433f3eacec34488e4fcd1ff08b"},
+    {file = "aws_cdk.aws_sam-1.89.0-py3-none-any.whl", hash = "sha256:279518d436f1b6adc33aeef46fa5b7c1c4a06034249de5cb42bc4dd87c3d0c01"},
 ]
 "aws-cdk.aws-secretsmanager" = [
-    {file = "aws-cdk.aws-secretsmanager-1.71.0.tar.gz", hash = "sha256:c5e753fe83911e15f26500d7de76b028684c100dac6782e65b22bd6ce5b70731"},
-    {file = "aws_cdk.aws_secretsmanager-1.71.0-py3-none-any.whl", hash = "sha256:73b52e82b47091a2710fa8f137d96ed55a8a8be22097fc93cefad09595c200dc"},
+    {file = "aws-cdk.aws-secretsmanager-1.89.0.tar.gz", hash = "sha256:7343f09b27830918c874312a5f10dc7f23ad159128299cf78ea6d79d407ffa63"},
+    {file = "aws_cdk.aws_secretsmanager-1.89.0-py3-none-any.whl", hash = "sha256:c91ae0c0873eef4146b2a0c14479afb05d319123f24e99357c9ff2797813d1c9"},
 ]
 "aws-cdk.aws-servicediscovery" = [
-    {file = "aws-cdk.aws-servicediscovery-1.71.0.tar.gz", hash = "sha256:950d6efaccaeb2efcb4da512c3ecfe774958d670063ea482b4acb1f0c726de9d"},
-    {file = "aws_cdk.aws_servicediscovery-1.71.0-py3-none-any.whl", hash = "sha256:f806e57c6a752d7e40c2a715c09bd1a0a0b51b2166004de38b8647422d588b98"},
+    {file = "aws-cdk.aws-servicediscovery-1.89.0.tar.gz", hash = "sha256:2a2676759bc390d67a60b813aa9c553a9579f414520b7a8065bfc0adb7f3acd0"},
+    {file = "aws_cdk.aws_servicediscovery-1.89.0-py3-none-any.whl", hash = "sha256:631a294554302cb90942bec1fd23c1b36bc20acf1b722b91759e7ba6dfe39209"},
 ]
 "aws-cdk.aws-sns" = [
-    {file = "aws-cdk.aws-sns-1.71.0.tar.gz", hash = "sha256:ff76d04585b98abc4071516ea70f606a98e499f6bccda23737bcd8a4d4307dfe"},
-    {file = "aws_cdk.aws_sns-1.71.0-py3-none-any.whl", hash = "sha256:42a890d16d2c95bf877766574e8929ecf96ebe8377f8f0e4b7faccd917b1833d"},
+    {file = "aws-cdk.aws-sns-1.89.0.tar.gz", hash = "sha256:89ab49d9ed56fdb927a709de4e0165517a75949607eb0773c709e960b9d53c06"},
+    {file = "aws_cdk.aws_sns-1.89.0-py3-none-any.whl", hash = "sha256:f9b42607db313f88760a43ae4e97571b9dd83b2c2a31770538bcbae8de277463"},
 ]
 "aws-cdk.aws-sns-subscriptions" = [
-    {file = "aws-cdk.aws-sns-subscriptions-1.71.0.tar.gz", hash = "sha256:6e0f2ba5c1058969578109f270490d79e4631afd25bf2083f90ac5d1db019ff6"},
-    {file = "aws_cdk.aws_sns_subscriptions-1.71.0-py3-none-any.whl", hash = "sha256:b10fb3ed2268ef2ef3a5e6d03eaa5f3b891e3922533fff4273ae1642169b66ca"},
+    {file = "aws-cdk.aws-sns-subscriptions-1.89.0.tar.gz", hash = "sha256:2cb1eac4181f11cfd02aa05ed4fbf157e52df691e593baf603310fccb367d34c"},
+    {file = "aws_cdk.aws_sns_subscriptions-1.89.0-py3-none-any.whl", hash = "sha256:dd2a5b34c2b53c2ee42b5dcad1a9fb15c10007de25b03a6915d76d6d76910a60"},
 ]
 "aws-cdk.aws-sqs" = [
-    {file = "aws-cdk.aws-sqs-1.71.0.tar.gz", hash = "sha256:8d8103f198b74f35853ec5bc971fd3afc47dbb5d9e04f12e258f45eda93105ec"},
-    {file = "aws_cdk.aws_sqs-1.71.0-py3-none-any.whl", hash = "sha256:da19e5f3557c397d03320cca6a492871cf6d7dca56458ecfebad2039519e0df7"},
+    {file = "aws-cdk.aws-sqs-1.89.0.tar.gz", hash = "sha256:ebb16ecb542974f0cc820781fbe2f0eabe47dd6bd51a16ef83225142ed21c3aa"},
+    {file = "aws_cdk.aws_sqs-1.89.0-py3-none-any.whl", hash = "sha256:3903231a5c2ea0632bd4c3f085cb25d9937e731ce37a36cded8a1fc5c9202275"},
 ]
 "aws-cdk.aws-ssm" = [
-    {file = "aws-cdk.aws-ssm-1.71.0.tar.gz", hash = "sha256:8aa44c34913ee176e5236ea064c5e29ea6324ef66ce4a450abf0aae55043e880"},
-    {file = "aws_cdk.aws_ssm-1.71.0-py3-none-any.whl", hash = "sha256:bdda7995fab281c79a4a82a7ff999557b14bb2cc9e5d8df96f7143ccbaa0ae8a"},
+    {file = "aws-cdk.aws-ssm-1.89.0.tar.gz", hash = "sha256:70ce7039b1403e06dbb694183e151299420ee9c937d9d4eeee2b70e5682a3976"},
+    {file = "aws_cdk.aws_ssm-1.89.0-py3-none-any.whl", hash = "sha256:bdf980311ea7b680ac7c2103bd7b229110f814601efef724ed447d90f61905b0"},
 ]
 "aws-cdk.aws-stepfunctions" = [
-    {file = "aws-cdk.aws-stepfunctions-1.71.0.tar.gz", hash = "sha256:48fd3af62bd0aaa377cd5d27910072563453c3498840a1060e7e8fe58731e2b1"},
-    {file = "aws_cdk.aws_stepfunctions-1.71.0-py3-none-any.whl", hash = "sha256:374134dfc5f70cd9ffabaa84a629fce2ddc85fd3229f867686e23817301e5ac3"},
+    {file = "aws-cdk.aws-stepfunctions-1.89.0.tar.gz", hash = "sha256:c9f19a09e2f0b6a1b18eab07ae171da6899a6ac17e2d2c296a3ba4cd708643fb"},
+    {file = "aws_cdk.aws_stepfunctions-1.89.0-py3-none-any.whl", hash = "sha256:3cb9d36c9905d819c268285b4937031107cd18aa8751daef420c111634af4802"},
 ]
 "aws-cdk.aws-stepfunctions-tasks" = [
-    {file = "aws-cdk.aws-stepfunctions-tasks-1.71.0.tar.gz", hash = "sha256:dba8717302a2490fe267478645d85e3f06bb7957141b787f9b1753d15bd8c4a5"},
-    {file = "aws_cdk.aws_stepfunctions_tasks-1.71.0-py3-none-any.whl", hash = "sha256:afe1f61eb915413236b1db521125d741e8872e67c6c384b69cba8a33b7c2c90c"},
+    {file = "aws-cdk.aws-stepfunctions-tasks-1.89.0.tar.gz", hash = "sha256:4a03cf37d4ed2774259680e3145416d82d827986573a5cfd1b4de10af4a7a086"},
+    {file = "aws_cdk.aws_stepfunctions_tasks-1.89.0-py3-none-any.whl", hash = "sha256:549fa33177e2792ed436f599e29d917c5f460ee3077226896c1b27078a49255f"},
 ]
 "aws-cdk.cloud-assembly-schema" = [
-    {file = "aws-cdk.cloud-assembly-schema-1.71.0.tar.gz", hash = "sha256:dc98e256844e4dab8cceb2f2e5899c22bd2bfb6fba685ccb2e73878c9ed374a2"},
-    {file = "aws_cdk.cloud_assembly_schema-1.71.0-py3-none-any.whl", hash = "sha256:4b4ca7c17095685be48e142d61dc3c7c98f0ed2fced516bb670b3d98ee125af5"},
+    {file = "aws-cdk.cloud-assembly-schema-1.89.0.tar.gz", hash = "sha256:94feab2eaa9b5c85dfbe2121228da5d62aa63f9d4e9ad92b02a3c64c6bca7cf2"},
+    {file = "aws_cdk.cloud_assembly_schema-1.89.0-py3-none-any.whl", hash = "sha256:d071d92cd68c275106f652d3eb64e5268218d9870cd4ce0062b1a0bfe2fda93b"},
 ]
 "aws-cdk.core" = [
-    {file = "aws-cdk.core-1.71.0.tar.gz", hash = "sha256:25c93d30ced04c8d3ea84dc63ad3341b35397a441ca518766f9b4475a7fc1553"},
-    {file = "aws_cdk.core-1.71.0-py3-none-any.whl", hash = "sha256:368b8cfde92f7d481722b813878a5fb5ffd5e7d0033cd0ca09aad8b63f8c6bdf"},
+    {file = "aws-cdk.core-1.89.0.tar.gz", hash = "sha256:fe7522dad68ce4b1455350052ec9df9a1aca43080cd319516abbbff27df3a5f0"},
+    {file = "aws_cdk.core-1.89.0-py3-none-any.whl", hash = "sha256:ead7e071a0658e05ac0597598e31609ba618cd1a0a6cb5c66a5f14d67e95d52d"},
 ]
 "aws-cdk.custom-resources" = [
-    {file = "aws-cdk.custom-resources-1.71.0.tar.gz", hash = "sha256:bc550473974077bf70af30741433c53b0f7a99aa08a2d475a7ba3b507bcbd1bd"},
-    {file = "aws_cdk.custom_resources-1.71.0-py3-none-any.whl", hash = "sha256:25725f40ca28cf750fc835ad3a6f1b1c628aa7347841ee1313e67c23029ccf6f"},
+    {file = "aws-cdk.custom-resources-1.89.0.tar.gz", hash = "sha256:57f8ac1766a253a1bce77e0d26c9b49079337c3a36463ca0d8979c18e98ca1ac"},
+    {file = "aws_cdk.custom_resources-1.89.0-py3-none-any.whl", hash = "sha256:6715271f9b5642705b765c467a849d4f8f8810e6dfc139027a43c70f3ff75c45"},
 ]
 "aws-cdk.cx-api" = [
-    {file = "aws-cdk.cx-api-1.71.0.tar.gz", hash = "sha256:38d8290722998daa83f5d484c8b91c9efa9fc9f03614768efe6cd7a9dfc3ebba"},
-    {file = "aws_cdk.cx_api-1.71.0-py3-none-any.whl", hash = "sha256:bf6e9a4b57d248fc0680e084b36335a3ea86f8f1443043615072363685d757e7"},
+    {file = "aws-cdk.cx-api-1.89.0.tar.gz", hash = "sha256:cea80180952c71966191838362acc50579dbce6c847ed4ae53c476c5f3accb52"},
+    {file = "aws_cdk.cx_api-1.89.0-py3-none-any.whl", hash = "sha256:0b71c3ac2a6b3f82b6eba40456f2738537a29780ea3f0066980e3bda8bd19984"},
 ]
 "aws-cdk.region-info" = [
-    {file = "aws-cdk.region-info-1.71.0.tar.gz", hash = "sha256:48125eaa7015d1ece0222019c1a0a4f4d3da16057b27d359b3b28b612c05650f"},
-    {file = "aws_cdk.region_info-1.71.0-py3-none-any.whl", hash = "sha256:9a75f1a835c396e637ec55f82fabc63c6d529027062c2908a0bc77e04383bf47"},
+    {file = "aws-cdk.region-info-1.89.0.tar.gz", hash = "sha256:475fd18c5df135a149b95d1d5d31c087ea4c1cd012f68bcc0346b7c44495a252"},
+    {file = "aws_cdk.region_info-1.89.0-py3-none-any.whl", hash = "sha256:3e7d2e2c726e4e24f198b8c046c5548f0aa89ca7b90574cbd1de69110fb90f10"},
 ]
 awscli = [
-    {file = "awscli-1.19.5-py2.py3-none-any.whl", hash = "sha256:f99851ca027696692e87bf96cdd0276ca7f92a27f698fe4a8d6ed768f6bacc3e"},
-    {file = "awscli-1.19.5.tar.gz", hash = "sha256:4b060bd958b06b33f630365b5bd7114e1be0ea354e32591fb1ba58e900ec8d06"},
+    {file = "awscli-1.19.6-py2.py3-none-any.whl", hash = "sha256:7cd7c0f21612a73f3380878336b8518e0e31b3a8006ecf77aef3a77b1e2dd200"},
+    {file = "awscli-1.19.6.tar.gz", hash = "sha256:c039140e3cc37e734d76f7ca0297cbcaf56e4846c49b496571f73135cd164df3"},
 ]
 backcall = [
     {file = "backcall-0.2.0-py2.py3-none-any.whl", hash = "sha256:fbbce6a29f263178a1f7915c1940bde0ec2b2a967566fe1c65c1dfb7422bd255"},
@@ -2404,20 +2460,20 @@ black = [
     {file = "black-20.8b1.tar.gz", hash = "sha256:1c02557aa099101b9d21496f8a914e9ed2222ef70336404eeeac8edba836fbea"},
 ]
 boto3 = [
-    {file = "boto3-1.17.5-py2.py3-none-any.whl", hash = "sha256:0d126d429a8a9ea2c8409a1ee36ce5a34e11db788d7730a714016264f10bbb89"},
-    {file = "boto3-1.17.5.tar.gz", hash = "sha256:d6aafb804fca2b67c65dda78ad8b4afed901e004071208b84c804d345ad9ebba"},
+    {file = "boto3-1.17.6-py2.py3-none-any.whl", hash = "sha256:f9d940f40c0302493466a20e716a23fa942b8e865dda4ebbca5e4fa3f5ca9635"},
+    {file = "boto3-1.17.6.tar.gz", hash = "sha256:bb2e16b0b8c13d47bc5d7b64a90bfa1310f4f2b524bdd3dcfe9237ddf243554d"},
 ]
 boto3-stubs = [
-    {file = "boto3-stubs-1.17.5.0.tar.gz", hash = "sha256:ba2a04396d29e2f4eb607d876afd4b5a83ebd0f18ed79867baccea4b5d515b34"},
-    {file = "boto3_stubs-1.17.5.0-py3-none-any.whl", hash = "sha256:7974f80d439de9a5c0fab51df6dad7e7938683b9fa212430dbb47618b2c48dfc"},
+    {file = "boto3-stubs-1.17.6.0.tar.gz", hash = "sha256:9cd052391624e5f6fc8802e605a89d13c89b986d197f687ace4b4555a9781113"},
+    {file = "boto3_stubs-1.17.6.0-py3-none-any.whl", hash = "sha256:8e4bfd26630d648f8425d521989d1dbd2b6d9ad6419bc0a18952d26480c6d148"},
 ]
 botocore = [
-    {file = "botocore-1.20.5-py2.py3-none-any.whl", hash = "sha256:3c55f0db5e08920727f4fa24a87aed60060643f4b0b5665c62ec762f79e82d6b"},
-    {file = "botocore-1.20.5.tar.gz", hash = "sha256:04a1df759681f5f171accb354d863bfed0774d64a4e8ee35ff49835755660a4e"},
+    {file = "botocore-1.20.6-py2.py3-none-any.whl", hash = "sha256:39832e4732fcdc897e1b1a50474251c7d3218029a902634a876364c223ca2432"},
+    {file = "botocore-1.20.6.tar.gz", hash = "sha256:7d04cd042ac01e08463dcbe520835d02f414ba431a43e4b4035bd2d0531b66a0"},
 ]
 cattrs = [
-    {file = "cattrs-1.2.0-py3-none-any.whl", hash = "sha256:6deb42a9166e00fe44f89cfa40ebe8d8164f31fa6001de90cced5ffac0622444"},
-    {file = "cattrs-1.2.0.tar.gz", hash = "sha256:daa70f0755d2e052b4854862f1c3afe2cc02d4de5f16fb72c249ac1608d2fd83"},
+    {file = "cattrs-1.1.2-py3-none-any.whl", hash = "sha256:967ce8f99b79f112a500fc03d02c4da669966055ea190b0c59a023af0ae33e5f"},
+    {file = "cattrs-1.1.2.tar.gz", hash = "sha256:a5873cd4745a74388557730247b4bb005d762f8aba0ab7aa55bcbd190bdf3322"},
 ]
 certifi = [
     {file = "certifi-2020.12.5-py2.py3-none-any.whl", hash = "sha256:719a74fb9e33b9bd44cc7f3a8d94bc35e4049deebe19ba7d8e108280cfd59830"},
@@ -2440,8 +2496,8 @@ colorama = [
     {file = "colorama-0.4.3.tar.gz", hash = "sha256:e96da0d330793e2cb9485e9ddfd918d456036c7149416295932478192f4436a1"},
 ]
 constructs = [
-    {file = "constructs-3.2.11-py3-none-any.whl", hash = "sha256:df25beaf8077872c896ad8747ce33b961b0ca4050c5c7e3af923069ff21e1f68"},
-    {file = "constructs-3.2.11.tar.gz", hash = "sha256:45eddf0cd4b33ed32f8c2105d02eb0e1e281619886048069624ae32845395af6"},
+    {file = "constructs-3.3.18-py3-none-any.whl", hash = "sha256:759219b202afefbcf5de72bf25d8d06e840f9bc168f1d80501f650781dbbede1"},
+    {file = "constructs-3.3.18.tar.gz", hash = "sha256:b003b525513f084131318bdf865ff61bc3cd1e53a36dba59b235561414f0d532"},
 ]
 coverage = [
     {file = "coverage-5.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:6d9c88b787638a451f41f97446a1c9fd416e669b4d9717ae4615bd29de1ac135"},
@@ -2556,8 +2612,8 @@ jmespath = [
     {file = "jmespath-0.10.0.tar.gz", hash = "sha256:b85d0567b8666149a93172712e68920734333c0ce7e89b78b3e987f71e5ed4f9"},
 ]
 jsii = [
-    {file = "jsii-1.14.0-py3-none-any.whl", hash = "sha256:00d520a6f74f6bd46b6f0f3e242a40e5fcc423409747001f74c24a1aaa7234c4"},
-    {file = "jsii-1.14.0.tar.gz", hash = "sha256:12c0dcb49b0da3bbd1ad661185ab2a52fdab86f5027476efcce8138f29f88115"},
+    {file = "jsii-1.20.1-py3-none-any.whl", hash = "sha256:a42213ed55314c42b5c093161e3573c24468747e7326384d5623d16a62cc0aa4"},
+    {file = "jsii-1.20.1.tar.gz", hash = "sha256:19b00aa6c7144424052a3ec9ba72b7ad7aa76c2efb4a5f6cbc16a8eb77dfe804"},
 ]
 jsonpointer = [
     {file = "jsonpointer-2.0-py2.py3-none-any.whl", hash = "sha256:ff379fa021d1b81ab539f5ec467c7745beb1a5671463f9dcc2b2d458bd361c1e"},
@@ -2626,28 +2682,28 @@ mypy = [
     {file = "mypy-0.800.tar.gz", hash = "sha256:e0202e37756ed09daf4b0ba64ad2c245d357659e014c3f51d8cd0681ba66940a"},
 ]
 mypy-boto3-batch = [
-    {file = "mypy-boto3-batch-1.17.5.0.tar.gz", hash = "sha256:e4c451756919db4957f6460a4a9ebb13d7cfc15b1a5db80029dc2f4e6c8498f4"},
-    {file = "mypy_boto3_batch-1.17.5.0-py3-none-any.whl", hash = "sha256:16851f6bcf00b6886b7fa7396a3a6e1b4d2c6644392ebb85a61f36976a6f3705"},
+    {file = "mypy-boto3-batch-1.17.6.0.tar.gz", hash = "sha256:24b847e10430844e42b79e6da346c5a065be632b04453e7814adb20f42bce267"},
+    {file = "mypy_boto3_batch-1.17.6.0-py3-none-any.whl", hash = "sha256:11fd58f9cdf9d8c1acf01178e94e0ed0e677ed5d69d2bce9fc6ce79461d7b89b"},
 ]
 mypy-boto3-dynamodb = [
-    {file = "mypy-boto3-dynamodb-1.17.5.0.tar.gz", hash = "sha256:55f12f7813389ef262123fd9aa7a3744bb709aa7a59c11c4be5469ad78b2ef51"},
-    {file = "mypy_boto3_dynamodb-1.17.5.0-py3-none-any.whl", hash = "sha256:a39855633691991431c8df2584e8d137125da1017ebb93b4fc8f2aceaf976333"},
+    {file = "mypy-boto3-dynamodb-1.17.6.0.tar.gz", hash = "sha256:4a86e9db74e48364995278ab4e0dae9102243c9e1c91192c7d109c86293f0067"},
+    {file = "mypy_boto3_dynamodb-1.17.6.0-py3-none-any.whl", hash = "sha256:df0a3d59c45b2d4735b9863acb899aee79fc3f065952e377d02f672d4d626a34"},
 ]
 mypy-boto3-lambda = [
-    {file = "mypy-boto3-lambda-1.17.5.0.tar.gz", hash = "sha256:668d62a4b3dace49be8d2bb1fd738d804466c7aa6eddda66035e8fa7e132eb76"},
-    {file = "mypy_boto3_lambda-1.17.5.0-py3-none-any.whl", hash = "sha256:21dee483f24f6e47b7ab9c5163b50c6adb53a130d95fbf6b752467680b040747"},
+    {file = "mypy-boto3-lambda-1.17.6.0.tar.gz", hash = "sha256:0cb731918d98d2f3f241e4b08ba38340d5c3b2b0757997d9fc95461eed1c43b0"},
+    {file = "mypy_boto3_lambda-1.17.6.0-py3-none-any.whl", hash = "sha256:49bb6ac217da1523da9728111e8ff01a65c638ee7312e7e1fbcb41748b45c7c3"},
 ]
 mypy-boto3-s3 = [
-    {file = "mypy-boto3-s3-1.17.5.0.tar.gz", hash = "sha256:91e25d9687482b6a42a80f0992dc1c81010f6e9d09e5989b6fdeaeda0fd20012"},
-    {file = "mypy_boto3_s3-1.17.5.0-py3-none-any.whl", hash = "sha256:054251124d3dfe5e410700f9da39f18bd3118737e2f67043767e50cc03c71fff"},
+    {file = "mypy-boto3-s3-1.17.6.0.tar.gz", hash = "sha256:f41ee4f3196f4ae1534bfec1c048c2afb24fa785f51ad0c1af16d8a49e89b6ad"},
+    {file = "mypy_boto3_s3-1.17.6.0-py3-none-any.whl", hash = "sha256:6e60be523cc8a867145d60c6ceb4401385e2ca566cae851995d479079aa66c92"},
 ]
 mypy-boto3-ssm = [
-    {file = "mypy-boto3-ssm-1.17.5.0.tar.gz", hash = "sha256:840dba753a2ca92798574ae8289ec3a2bb04cd7fde0a277f9e69451deb9b209e"},
-    {file = "mypy_boto3_ssm-1.17.5.0-py3-none-any.whl", hash = "sha256:a7117eb9c19f7302b5051876e86aa7f54f0c899143a8cd5bf6992c0ecd57594b"},
+    {file = "mypy-boto3-ssm-1.17.6.0.tar.gz", hash = "sha256:7f7be2acd0e4f3f0c8de342187c6944713d74116bf040af6a1a0f6dce4e776d3"},
+    {file = "mypy_boto3_ssm-1.17.6.0-py3-none-any.whl", hash = "sha256:a05a30d6f724c8411be12f90bad7ae50196e20f86928424e6d789612cc64eeab"},
 ]
 mypy-boto3-stepfunctions = [
-    {file = "mypy-boto3-stepfunctions-1.17.5.0.tar.gz", hash = "sha256:33e809297dbd7de98abc1797340e05b28153624e1243208ce178ca0fb2080d65"},
-    {file = "mypy_boto3_stepfunctions-1.17.5.0-py3-none-any.whl", hash = "sha256:c4fa44f9d13567731f274ec3c5c37b54f54ae38e383a99fe56c344bc712ba8c0"},
+    {file = "mypy-boto3-stepfunctions-1.17.6.0.tar.gz", hash = "sha256:fff866dbe3aad786f77eda5953b42cd971753bffedfa8a124c8fc21854ab7129"},
+    {file = "mypy_boto3_stepfunctions-1.17.6.0-py3-none-any.whl", hash = "sha256:db701228c65bdf3ab4fa08020a255a98297d6466f3bdb501370f314ba06ee866"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -2686,8 +2742,8 @@ pre-commit = [
     {file = "pre_commit-2.10.1.tar.gz", hash = "sha256:399baf78f13f4de82a29b649afd74bef2c4e28eb4f021661fc7f29246e8c7a3a"},
 ]
 prompt-toolkit = [
-    {file = "prompt_toolkit-3.0.14-py3-none-any.whl", hash = "sha256:c96b30925025a7635471dc083ffb6af0cc67482a00611bd81aeaeeeb7e5a5e12"},
-    {file = "prompt_toolkit-3.0.14.tar.gz", hash = "sha256:7e966747c18ececaec785699626b771c1ba8344c8d31759a1915d6b12fad6525"},
+    {file = "prompt_toolkit-3.0.16-py3-none-any.whl", hash = "sha256:62c811e46bd09130fb11ab759012a4ae385ce4fb2073442d1898867a824183bd"},
+    {file = "prompt_toolkit-3.0.16.tar.gz", hash = "sha256:0fa02fa80363844a4ab4b8d6891f62dd0645ba672723130423ca4037b80c1974"},
 ]
 ptyprocess = [
     {file = "ptyprocess-0.7.0-py2.py3-none-any.whl", hash = "sha256:4b41f3967fce3af57cc7e94b888626c18bf37a083e3651ca8feeb66d492fef35"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ version = "*"
 optional = true
 
 [tool.poetry.dependencies."aws-cdk.aws-ecs"]
-version = "*"
+version = "^1.73"
 optional = true
 
 [tool.poetry.dependencies."aws-cdk.aws-iam"]


### PR DESCRIPTION
By forcing a more recent version we re-enable .dockerignore support
<https://github.com/aws/aws-cdk/releases/tag/v1.73.0>.

This partially reverts commit a097a5abb49281e404309ea8b1f514c01e5dc696.