### PR TITLE
feat: Remove cdk.out as part of dev env reset

### DIFF
--- a/reset-dev-env.bash
+++ b/reset-dev-env.bash
@@ -78,6 +78,8 @@ cd "$(dirname "${BASH_SOURCE[0]}")"
 if [[ -n "${delete-}" ]]
 then
     echo "Cleaning Git repository"
+    # TODO: Remove next line after fixing https://github.com/linz/geospatial-data-lake/issues/253
+    rm --force --recursive cdk.out
     git clean -d --force -x
 fi
 


### PR DESCRIPTION
Until we fix <https://github.com/linz/geospatial-data-lake/issues/253>.