### PR TITLE
refactor: Remove dependency on `unittest.TestCase`

### DIFF
--- a/datalake/backend/tests/test_check_stac_metadata_logging.py
+++ b/datalake/backend/tests/test_check_stac_metadata_logging.py
@@ -2,7 +2,6 @@ import logging
 import sys
 from json import dumps
 from random import choice
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from jsonschema import ValidationError  # type: ignore[import]
@@ -11,7 +10,7 @@ from ..processing.check_stac_metadata.task import main
 from .utils import any_dataset_id, any_dataset_version_id, any_program_name, any_s3_url
 
 
-class LogTests(TestCase):
+class TestLogging:
     logger: logging.Logger
 
     @classmethod

--- a/datalake/backend/tests/test_dataset_versions_endpoint_logging.py
+++ b/datalake/backend/tests/test_dataset_versions_endpoint_logging.py
@@ -1,6 +1,5 @@
 import logging
 from json import dumps
-from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from jsonschema import ValidationError  # type: ignore[import]
@@ -11,7 +10,7 @@ from ..endpoints.dataset_versions.create import create_dataset_version
 from .utils import Dataset, any_dataset_id, any_s3_url, any_valid_dataset_type
 
 
-class LogTests(TestCase):
+class TestLogging:
     logger: logging.Logger
 
     @classmethod


### PR DESCRIPTION
By renaming the test class it runs as under pytest without inheriting
from `TestCase`. This makes it possible to use pytest fixtures
<https://docs.pytest.org/en/latest/xunit_setup.html>.