### PR TITLE
feat: Copy fewer files when creating CDK Docker assets

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,12 @@
-.venv
 cdk.out
+.coverage
+.git
+.github
+.idea
+.mypy_cache/
 node_modules
+*.pyc
 __pycache__
+.pytest_cache
+.venv
+.vscode


### PR DESCRIPTION
This uses a bit less disk space for cdk.out. Most importantly it doesn't copy .git and other files/directories which change often, meaning that rebuilds should be faster.

Before: 

```
$ rm --force --recursive cdk.out && time cdk synth && du -hs cdk.out
[…]
3m59.181s
[…]
216M	cdk.out
```

After:

```
$ rm --force --recursive cdk.out && time cdk synth && du -hs cdk.out
[…]
real	4m6.420s
[…]
135M	cdk.out
```