### PR TITLE
feat: Use non-root user in Docker

### DIFF
--- a/datalake/backend/processing/Dockerfile
+++ b/datalake/backend/processing/Dockerfile
@@ -23,6 +23,8 @@ RUN apt-get update \
     && apt-get install --assume-yes --no-install-recommends ca-certificates python3 \
     && rm -rf /var/lib/apt/lists/*
 
+USER 10000:10000
+
 COPY --from=build /opt/.venv /opt/.venv
 
 COPY datalake/backend/processing/*.py /src/


### PR DESCRIPTION
As it turns out, the UID/GID don't actually have to map to an existing
user for this to work.

As recommended by
<https://cloudberry.engineering/article/dockerfile-security-best-practices/>,
<https://github.com/hexops/dockerfile> and
<https://engineering.bitnami.com/articles/why-non-root-containers-are-important-for-security.html>.

This closes issue https://github.com/linz/geospatial-data-lake/issues/197