### PR TITLE
fix: Use default GitHub merge commit message

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -8,5 +8,3 @@ method = "squash"
 
 [merge.message]
 title = "pull_request_title"
-include_coauthors = true
-include_pull_request_url = true


### PR DESCRIPTION
The commit message should include all messages from all commits in the
pull request. See <https://github.com/chdsbd/kodiak/issues/622>.