### PR TITLE
fix: Change dependabot time configuration value to string

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,5 +23,5 @@ updates:
   schedule:
     interval: weekly
     day: friday
-    time: 15:00
+    time: "15:00"
     timezone: Pacific/Auckland

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -57,14 +57,16 @@ repos:
     stages: [commit]
     types: [toml]
 
-  - id: pretty-format-yaml
-    name: Pretty format YAML
-    entry: pretty-format-yaml
-    args: [--autofix]
-    language: system
-    stages: [commit]
-    types: [yaml]
-
+# Reintroduce once https://github.com/dependabot/dependabot-core/issues/3263 and/or
+# https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/53 have been resolved
+#  - id: pretty-format-yaml
+#    name: Pretty format YAML
+#    entry: pretty-format-yaml
+#    args: [--autofix]
+#    language: system
+#    stages: [commit]
+#    types: [yaml]
+#
   - id: pylint
     name: pylint
     entry: pylint


### PR DESCRIPTION
See <https://github.com/dependabot/dependabot-core/issues/3263> /
<https://github.com/macisamuele/language-formatters-pre-commit-hooks/issues/53>.