### PR TITLE
feat(infra): store deployment version as SSM parameter

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -36,7 +36,7 @@ jobs:
 
     - name: Get current production environment version
       run: |
-          echo "PROD_VERSION=$(aws cloudformation describe-stacks --stack-name prod-geospatial-data-lake-storage --query 'Stacks[].Tags[?Key==`Version`].Value[]' --output text)" | tee -a $GITHUB_ENV
+          echo "PROD_VERSION=$(aws ssm get-parameter --name /prod/version --query Parameter.Value --output text || true)" | tee -a $GITHUB_ENV
 
     - name: Checkout to current production version
       run: git checkout ${{ env.PROD_VERSION }}

--- a/app.py
+++ b/app.py
@@ -3,7 +3,6 @@
 """
 CDK application entry point file.
 """
-import subprocess
 from os import environ
 
 from aws_cdk.core import App, Environment, Tag
@@ -62,46 +61,12 @@ def main() -> None:
     )
 
     # tag all resources in stack
-    git_branch = (
-        subprocess.Popen(
-            ["git", "rev-parse", "--abbrev-ref", "HEAD"], shell=False, stdout=subprocess.PIPE
-        )
-        .communicate()[0]
-        .decode()
-        .strip()
-    )
-    git_commit = (
-        subprocess.Popen(
-            ["git", "rev-parse", "--short", "HEAD"], shell=False, stdout=subprocess.PIPE
-        )
-        .communicate()[0]
-        .decode()
-        .strip()
-    )
-
-    git_tag = (
-        subprocess.Popen(
-            ["git", "describe", "--tags", "--exact-match"],
-            shell=False,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.DEVNULL,
-        )
-        .communicate()[0]
-        .decode()
-        .strip()
-    )
-    if not git_tag:
-        git_tag = "UNRELEASED"
-
     Tag.add(app, "CostCentre", "100005")
     Tag.add(app, APPLICATION_NAME_TAG_NAME, APPLICATION_NAME)
     Tag.add(app, "Owner", "Bill M. Nelson")
     Tag.add(app, "EnvironmentType", ENV)
     Tag.add(app, "SupportType", "Dev")
     Tag.add(app, "HoursOfOperation", "24x7")
-    Tag.add(app, "GitBranch", f"{git_branch}")
-    Tag.add(app, "GitCommit", f"{git_commit}")
-    Tag.add(app, "Version", f"{git_tag}")
 
     app.synth()
 

--- a/backend/version.py
+++ b/backend/version.py
@@ -1,0 +1,30 @@
+import subprocess
+
+GIT_BRANCH = (
+    subprocess.Popen(
+        ["git", "rev-parse", "--abbrev-ref", "HEAD"], shell=False, stdout=subprocess.PIPE
+    )
+    .communicate()[0]
+    .decode()
+    .strip()
+)
+GIT_COMMIT = (
+    subprocess.Popen(["git", "rev-parse", "--short", "HEAD"], shell=False, stdout=subprocess.PIPE)
+    .communicate()[0]
+    .decode()
+    .strip()
+)
+
+GIT_TAG = (
+    subprocess.Popen(
+        ["git", "describe", "--tags", "--exact-match"],
+        shell=False,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+    )
+    .communicate()[0]
+    .decode()
+    .strip()
+)
+if not GIT_TAG:
+    GIT_TAG = "UNRELEASED"

--- a/infrastructure/storage_stack.py
+++ b/infrastructure/storage_stack.py
@@ -9,6 +9,7 @@ from aws_cdk.core import Construct, RemovalPolicy, Stack, Tags
 from backend.datasets_model import DatasetsTitleIdx
 from backend.environment import ENV
 from backend.parameter_store import ParameterName
+from backend.version import GIT_BRANCH, GIT_COMMIT, GIT_TAG
 
 from .constructs.table import Table
 
@@ -22,6 +23,34 @@ class StorageStack(Stack):
             resource_removal_policy = RemovalPolicy.RETAIN
         else:
             resource_removal_policy = RemovalPolicy.DESTROY
+
+        ############################################################################################
+        # ### DEPLOYMENT VERSION ###################################################################
+        ############################################################################################
+
+        aws_ssm.StringParameter(
+            self,
+            "git-branch",
+            parameter_name=f"/{ENV}/git_branch",
+            string_value=GIT_BRANCH,
+            description="Deployment git branch",
+        )
+
+        aws_ssm.StringParameter(
+            self,
+            "git-commit",
+            parameter_name=f"/{ENV}/git_commit",
+            string_value=GIT_COMMIT,
+            description="Deployment git commit",
+        )
+
+        aws_ssm.StringParameter(
+            self,
+            "git-tag",
+            parameter_name=f"/{ENV}/version",
+            string_value=GIT_TAG,
+            description="Deployment version",
+        )
 
         ############################################################################################
         # ### STORAGE S3 BUCKET ####################################################################


### PR DESCRIPTION
Store deployment version as SSM Parameter instead of CloudFormation stack tag. CloudFormation stack tags are applied recursively to all resources which is causing changes to all resources during all deployments and making CloudFormation changesets unreadable. This change is fixing this issue.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
