### PR TITLE
feat: Run CodeQL on non-master branches only on pull request event

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -2,6 +2,8 @@ name: CodeQL Analysis
 
 on:
   push:
+    branches: [master]
+  pull_request:
   schedule:
   - cron: 0 16 * * 2
 


### PR DESCRIPTION
This should make the Dependabot pull request actions pass, because pull
request event actions have write access to save the CodeQL reports. See
<https://docs.github.com/en/code-security/secure-coding/configuring-code-scanning#scanning-on-push>
for details.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
