### PR TITLE
fix: Run CodeQL analysis on optional Python dependencies

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -14,11 +14,25 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v2
 
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install poetry
+        python -m poetry install \
+            --extras='cdk check_files_checksums check_stac_metadata content_iterator datasets dataset_versions import_dataset import_status validation_summary'
+        echo "CODEQL_PYTHON=$(python -m poetry run which python)" >> $GITHUB_ENV
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v1
       with:
         config-file: ./.github/codeql/codeql-config.yml
+        setup-python-dependencies: false
       # Override language selection by uncommenting this and choosing your languages
       # with:
       #   languages: go, javascript, csharp, python, cpp, java


### PR DESCRIPTION
The default CodeQL setup installs only the non-extras - see for example
<https://github.com/linz/geospatial-data-lake/runs/2335212930>.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
