### PR TITLE
feat: Install wheel package during bundling

### DIFF
--- a/backend/bundle.bash
+++ b/backend/bundle.bash
@@ -18,7 +18,7 @@ python -m venv "${work_dir}/.venv"
 # shellcheck source=/dev/null
 . "${work_dir}/.venv/bin/activate"
 python -m pip install --cache-dir="$work_dir" --upgrade pip
-python -m pip install --cache-dir="$work_dir" poetry
+python -m pip install --cache-dir="$work_dir" poetry wheel
 
 asset_root='/asset-output'
 task_directory="$(basename "$1")"


### PR DESCRIPTION
Avoids some packages complaining about "Using legacy 'setup.py
install'", which presumably is unwanted.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
