### PR TITLE
fix: bug template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -36,8 +36,8 @@ Environment: <!-- e.g. production -->
 
 Relevant software versions:
 
-- AWS CLI: <!-- include the output of `aws --version` -->
-- Poetry: <!-- include the output of `poetry --version` -->
+- AWS CLI: <!-- include the output of `aws \-\-version` -->
+- Poetry: <!-- include the output of `poetry \-\-version` -->
 <!-- Any other relevant software -->
 
 ## Additional context


### PR DESCRIPTION
Escape dashes in markdown comments
Github was formatting the comments as text, so they weren't hidden.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
