### PR TITLE
feat: implement separate configuration for resource removal policy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
           submodules: 'true'
           fetch-depth: 0
 
-        # prod version detection
+      # prod version detection
       - name: Configure production AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -38,7 +38,7 @@ jobs:
       - name: Checkout to current production version
         run: git checkout ${{ env.PROD_VERSION }}
 
-        # dependencies installation
+      # dependencies installation
       - name: Use Node for CDK deployment
         uses: actions/setup-node@v2.1.5
         with:
@@ -82,7 +82,7 @@ jobs:
       - name: Print CDK version
         run: poetry run cdk --version
 
-        # deployment
+      # deployment
       - name: Configure CI AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -96,6 +96,7 @@ jobs:
         run: |
           DEPLOY_ENV="ci${GITHUB_RUN_ID}"
           echo "DEPLOY_ENV=$DEPLOY_ENV" | tee -a $GITHUB_ENV
+          echo "RESOURCE_REMOVAL_POLICY=RETAIN" | tee -a $GITHUB_ENV
 
       - name: Deploy copy of production AWS stacks in to CI environment
         run: |
@@ -115,7 +116,7 @@ jobs:
         with:
           submodules: 'true'
 
-        # dependencies installation
+      # dependencies installation
       - name: Use Node for CDK deployment
         uses: actions/setup-node@v2.1.5
         with:
@@ -159,7 +160,7 @@ jobs:
       - name: Print CDK version
         run: poetry run cdk --version
 
-        # deployment
+      # deployment
       - name: Configure CI AWS credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
@@ -173,6 +174,7 @@ jobs:
         run: |
           DEPLOY_ENV="ci${GITHUB_RUN_ID}"
           echo "DEPLOY_ENV=$DEPLOY_ENV" | tee -a $GITHUB_ENV
+          echo "RESOURCE_REMOVAL_POLICY=RETAIN" | tee -a $GITHUB_ENV
 
       - name: Upgrade copy of production AWS stacks in CI environment
         run: |
@@ -239,7 +241,7 @@ jobs:
       - name: Print CDK version
         run: poetry run cdk --version
 
-        # NONPROD DEPLOYMENT - deploy all changes in master branch
+      # NONPROD DEPLOYMENT - deploy all changes in master branch
       - name: (NonProd) Configure AWS credentials
         if: >
           github.ref == 'refs/heads/master' && github.repository == 'linz/geospatial-data-lake'
@@ -262,7 +264,7 @@ jobs:
           DATALAKE_SAML_IDENTITY_PROVIDER_ARN:
             ${{ secrets.DATALAKE_SAML_IDENTITY_PROVIDER_ARN_NON_PROD }}
 
-        # PROD DEPLOYMENT - in release branch, deploy on tag, otherwise report stack changes only
+      # PROD DEPLOYMENT - in release branch, deploy on tag, otherwise report stack changes only
       - name: (Prod) Configure AWS credentials
         if: >
           startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref,

--- a/README.md
+++ b/README.md
@@ -152,6 +152,12 @@ Re-run `. .venv/bin/activate` in each shell.
      Other values used by CI pipelines include: prod, nonprod, ci, dev or any string without spaces.
      Default: dev.
 
+   * **`RESOURCE_REMOVAL_POLICY`:** determines if resources containing user content like Data Lake
+     Storage S3 bucket or application database tables will be preserved even if the are removed from
+     stack or stack is deleted. Supported values:
+     - DESTROY: destroy resource when removed from stack or stack is deleted (default)
+     - RETAIN: retain orphaned resource when removed from stack or stack is deleted
+
    - **`DATALAKE_SAML_IDENTITY_PROVIDER_ARN`:** SAML identity provider AWS ARN.
 
 1. Bootstrap CDK (only once per profile)

--- a/infrastructure/constructs/table.py
+++ b/infrastructure/constructs/table.py
@@ -1,9 +1,10 @@
 from typing import Optional
 
 from aws_cdk import aws_dynamodb, aws_ssm
-from aws_cdk.core import Construct, RemovalPolicy, Tags
+from aws_cdk.core import Construct, Tags
 
 from backend.parameter_store import ParameterName
+from infrastructure.removal_policy import REMOVAL_POLICY
 
 
 class Table(aws_dynamodb.Table):
@@ -17,10 +18,6 @@ class Table(aws_dynamodb.Table):
         parameter_name: ParameterName,
         sort_key: Optional[aws_dynamodb.Attribute] = None,
     ):
-        if deploy_env == "prod":
-            resource_removal_policy = RemovalPolicy.RETAIN
-        else:
-            resource_removal_policy = RemovalPolicy.DESTROY
 
         super().__init__(
             scope,
@@ -28,7 +25,7 @@ class Table(aws_dynamodb.Table):
             partition_key=aws_dynamodb.Attribute(name="pk", type=aws_dynamodb.AttributeType.STRING),
             sort_key=sort_key,
             point_in_time_recovery=True,
-            removal_policy=resource_removal_policy,
+            removal_policy=REMOVAL_POLICY,
             billing_mode=aws_dynamodb.BillingMode.PAY_PER_REQUEST,
         )
 

--- a/infrastructure/removal_policy.py
+++ b/infrastructure/removal_policy.py
@@ -1,0 +1,9 @@
+import os
+
+from aws_cdk.core import RemovalPolicy
+
+if os.environ.get("RESOURCE_REMOVAL_POLICY", "DESTROY").upper() == "RETAIN":
+    REMOVAL_POLICY = RemovalPolicy.RETAIN
+
+else:
+    REMOVAL_POLICY = RemovalPolicy.DESTROY

--- a/infrastructure/storage_stack.py
+++ b/infrastructure/storage_stack.py
@@ -4,13 +4,14 @@ Data Lake AWS resources definitions.
 from typing import Any
 
 from aws_cdk import aws_dynamodb, aws_s3, aws_ssm
-from aws_cdk.core import Construct, RemovalPolicy, Stack, Tags
+from aws_cdk.core import Construct, Stack, Tags
 
 from backend.datasets_model import DatasetsTitleIdx
 from backend.environment import ENV
 from backend.parameter_store import ParameterName
 from backend.validation_results_model import ValidationOutcomeIdx
 from backend.version import GIT_BRANCH, GIT_COMMIT, GIT_TAG
+from infrastructure.removal_policy import REMOVAL_POLICY
 
 from .constructs.table import Table
 
@@ -18,12 +19,6 @@ from .constructs.table import Table
 class StorageStack(Stack):
     def __init__(self, scope: Construct, stack_id: str, deploy_env: str, **kwargs: Any) -> None:
         super().__init__(scope, stack_id, **kwargs)
-
-        # set resources depending on deployment type
-        if deploy_env == "prod":
-            resource_removal_policy = RemovalPolicy.RETAIN
-        else:
-            resource_removal_policy = RemovalPolicy.DESTROY
 
         ############################################################################################
         # ### DEPLOYMENT VERSION ###################################################################
@@ -62,7 +57,7 @@ class StorageStack(Stack):
             access_control=aws_s3.BucketAccessControl.PRIVATE,
             block_public_access=aws_s3.BlockPublicAccess.BLOCK_ALL,
             versioned=True,
-            removal_policy=resource_removal_policy,
+            removal_policy=REMOVAL_POLICY,
         )
         Tags.of(self.storage_bucket).add("ApplicationLayer", "storage")  # type: ignore[arg-type]
 


### PR DESCRIPTION
This change add separate resources removal policy in order to be able to set it to `RETAIN` for CI deployments which are testing production deployment upgrades.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
