### PR TITLE
refactor(infra): use nested stacks with cross-stack references passed using parameters

### DIFF
--- a/infrastructure/api_stack.py
+++ b/infrastructure/api_stack.py
@@ -1,11 +1,12 @@
 """
 Data Lake AWS resources definitions.
 """
+from dataclasses import dataclass
 from os import environ
 from typing import Any
 
 from aws_cdk import aws_iam, aws_lambda_python, aws_s3, aws_ssm, aws_stepfunctions
-from aws_cdk.core import Construct, Stack, Tags
+from aws_cdk.core import Construct, NestedStack, NestedStackProps, Tags
 
 from backend.resources import ResourceName
 
@@ -15,7 +16,18 @@ from .constructs.table import Table
 from .roles import MAX_SESSION_DURATION
 
 
-class APIStack(Stack):
+@dataclass
+class APIStackProps(NestedStackProps):
+    botocore_lambda_layer: aws_lambda_python.PythonLayerVersion
+    datasets_table: Table
+    state_machine: aws_stepfunctions.StateMachine
+    state_machine_parameter: aws_ssm.StringParameter
+    storage_bucket: aws_s3.Bucket
+    storage_bucket_parameter: aws_ssm.StringParameter
+    validation_results_table: Table
+
+
+class APIStack(NestedStack):
     """Data Lake stack definition."""
 
     def __init__(  # pylint: disable=too-many-arguments,too-many-locals
@@ -23,14 +35,8 @@ class APIStack(Stack):
         scope: Construct,
         stack_id: str,
         *,
-        botocore_lambda_layer: aws_lambda_python.PythonLayerVersion,
-        datasets_table: Table,
         deploy_env: str,
-        state_machine: aws_stepfunctions.StateMachine,
-        state_machine_parameter: aws_ssm.StringParameter,
-        storage_bucket: aws_s3.Bucket,
-        storage_bucket_parameter: aws_ssm.StringParameter,
-        validation_results_table: Table,
+        props: APIStackProps,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, stack_id, **kwargs)
@@ -62,7 +68,7 @@ class APIStack(Stack):
             assumed_by=principal,  # type: ignore[arg-type]
             max_session_duration=MAX_SESSION_DURATION,
         )
-        storage_bucket.grant_read(read_only_role)  # type: ignore[arg-type]
+        props.storage_bucket.grant_read(read_only_role)  # type: ignore[arg-type]
 
         ############################################################################################
         # ### API ENDPOINTS ########################################################################
@@ -74,7 +80,7 @@ class APIStack(Stack):
             package_name="datasets",
             deploy_env=deploy_env,
             users_role=users_role,
-            botocore_lambda_layer=botocore_lambda_layer,
+            botocore_lambda_layer=props.botocore_lambda_layer,
         ).lambda_function
 
         dataset_versions_endpoint_lambda = LambdaEndpoint(
@@ -83,17 +89,17 @@ class APIStack(Stack):
             package_name="dataset_versions",
             deploy_env=deploy_env,
             users_role=users_role,
-            botocore_lambda_layer=botocore_lambda_layer,
+            botocore_lambda_layer=props.botocore_lambda_layer,
         ).lambda_function
 
-        state_machine.grant_start_execution(dataset_versions_endpoint_lambda)
+        props.state_machine.grant_start_execution(dataset_versions_endpoint_lambda)
 
-        storage_bucket.grant_read(datasets_endpoint_lambda)
-        storage_bucket_parameter.grant_read(datasets_endpoint_lambda)
+        props.storage_bucket.grant_read(datasets_endpoint_lambda)
+        props.storage_bucket_parameter.grant_read(datasets_endpoint_lambda)
 
         for function in [datasets_endpoint_lambda, dataset_versions_endpoint_lambda]:
-            datasets_table.grant_read_write_data(function)
-            datasets_table.grant(function, "dynamodb:DescribeTable")  # required by pynamodb
+            props.datasets_table.grant_read_write_data(function)
+            props.datasets_table.grant(function, "dynamodb:DescribeTable")  # required by pynamodb
 
         import_status_endpoint_lambda = LambdaEndpoint(
             self,
@@ -101,15 +107,15 @@ class APIStack(Stack):
             package_name="import_status",
             deploy_env=deploy_env,
             users_role=users_role,
-            botocore_lambda_layer=botocore_lambda_layer,
+            botocore_lambda_layer=props.botocore_lambda_layer,
         ).lambda_function
 
-        validation_results_table.grant_read_data(import_status_endpoint_lambda)
-        validation_results_table.grant(
+        props.validation_results_table.grant_read_data(import_status_endpoint_lambda)
+        props.validation_results_table.grant(
             import_status_endpoint_lambda, "dynamodb:DescribeTable"
         )  # required by pynamodb
 
-        state_machine.grant_read(import_status_endpoint_lambda)
+        props.state_machine.grant_read(import_status_endpoint_lambda)
         assert import_status_endpoint_lambda.role is not None
         import_status_endpoint_lambda.role.add_to_policy(
             aws_iam.PolicyStatement(
@@ -120,12 +126,12 @@ class APIStack(Stack):
 
         grant_parameter_read_access(
             {
-                datasets_table.name_parameter: [
+                props.datasets_table.name_parameter: [
                     datasets_endpoint_lambda,
                     dataset_versions_endpoint_lambda,
                 ],
-                validation_results_table.name_parameter: [import_status_endpoint_lambda],
-                state_machine_parameter: [dataset_versions_endpoint_lambda],
+                props.validation_results_table.name_parameter: [import_status_endpoint_lambda],
+                props.state_machine_parameter: [dataset_versions_endpoint_lambda],
             }
         )
 

--- a/infrastructure/lambda_layers_stack.py
+++ b/infrastructure/lambda_layers_stack.py
@@ -2,12 +2,12 @@ from typing import Any
 
 import constructs
 from aws_cdk import aws_lambda_python
-from aws_cdk.core import Stack
+from aws_cdk.core import NestedStack
 
 from .runtime import PYTHON_RUNTIME
 
 
-class LambdaLayersStack(Stack):
+class LambdaLayersStack(NestedStack):
     def __init__(
         self,
         scope: constructs.Construct,

--- a/infrastructure/lds.py
+++ b/infrastructure/lds.py
@@ -1,15 +1,9 @@
-from dataclasses import dataclass
 from typing import Any
 
 from aws_cdk import aws_iam, aws_s3
-from aws_cdk.core import Construct, NestedStack, NestedStackProps, Tags
+from aws_cdk.core import Construct, NestedStack, Tags
 
 from .roles import MAX_SESSION_DURATION
-
-
-@dataclass
-class LDSStackProps(NestedStackProps):
-    storage_bucket: aws_s3.Bucket
 
 
 class LDSStack(NestedStack):
@@ -19,7 +13,7 @@ class LDSStack(NestedStack):
         stack_id: str,
         *,
         deploy_env: str,
-        props: LDSStackProps,
+        storage_bucket: aws_s3.Bucket,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, stack_id, **kwargs)
@@ -33,6 +27,6 @@ class LDSStack(NestedStack):
             external_id={"prod": "koordinates-jAddR"}.get(deploy_env, "koordinates-4BnJQ"),
             max_session_duration=MAX_SESSION_DURATION,
         )
-        props.storage_bucket.grant_read(role)  # type: ignore[arg-type]
+        storage_bucket.grant_read(role)  # type: ignore[arg-type]
 
         Tags.of(self).add("ApplicationLayer", "lds")  # type: ignore[arg-type]

--- a/infrastructure/lds.py
+++ b/infrastructure/lds.py
@@ -1,19 +1,25 @@
+from dataclasses import dataclass
 from typing import Any
 
 from aws_cdk import aws_iam, aws_s3
-from aws_cdk.core import Construct, Stack, Tags
+from aws_cdk.core import Construct, NestedStack, NestedStackProps, Tags
 
 from .roles import MAX_SESSION_DURATION
 
 
-class LDSStack(Stack):
+@dataclass
+class LDSStackProps(NestedStackProps):
+    storage_bucket: aws_s3.Bucket
+
+
+class LDSStack(NestedStack):
     def __init__(
         self,
         scope: Construct,
         stack_id: str,
         *,
         deploy_env: str,
-        storage_bucket: aws_s3.Bucket,
+        props: LDSStackProps,
         **kwargs: Any,
     ) -> None:
         super().__init__(scope, stack_id, **kwargs)
@@ -27,6 +33,6 @@ class LDSStack(Stack):
             external_id={"prod": "koordinates-jAddR"}.get(deploy_env, "koordinates-4BnJQ"),
             max_session_duration=MAX_SESSION_DURATION,
         )
-        storage_bucket.grant_read(role)  # type: ignore[arg-type]
+        props.storage_bucket.grant_read(role)  # type: ignore[arg-type]
 
         Tags.of(self).add("ApplicationLayer", "lds")  # type: ignore[arg-type]

--- a/infrastructure/staging_stack.py
+++ b/infrastructure/staging_stack.py
@@ -1,13 +1,20 @@
 from typing import Any
 
 from aws_cdk import aws_s3, aws_ssm
-from aws_cdk.core import Construct, RemovalPolicy, Stack, Tags
+from aws_cdk.core import Construct, NestedStack, RemovalPolicy, Tags
 
 from backend.parameter_store import ParameterName
 
 
-class StagingStack(Stack):
-    def __init__(self, scope: Construct, stack_id: str, *, deploy_env: str, **kwargs: Any) -> None:
+class StagingStack(NestedStack):
+    def __init__(
+        self,
+        scope: Construct,
+        stack_id: str,
+        *,
+        deploy_env: str,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(scope, stack_id, **kwargs)
 
         ############################################################################################

--- a/infrastructure/staging_stack.py
+++ b/infrastructure/staging_stack.py
@@ -7,14 +7,7 @@ from backend.parameter_store import ParameterName
 
 
 class StagingStack(NestedStack):
-    def __init__(
-        self,
-        scope: Construct,
-        stack_id: str,
-        *,
-        deploy_env: str,
-        **kwargs: Any,
-    ) -> None:
+    def __init__(self, scope: Construct, stack_id: str, *, deploy_env: str, **kwargs: Any) -> None:
         super().__init__(scope, stack_id, **kwargs)
 
         ############################################################################################

--- a/infrastructure/storage_stack.py
+++ b/infrastructure/storage_stack.py
@@ -16,14 +16,7 @@ from .removal_policy import REMOVAL_POLICY
 
 
 class StorageStack(NestedStack):
-    def __init__(
-        self,
-        scope: Construct,
-        stack_id: str,
-        *,
-        deploy_env: str,
-        **kwargs: Any,
-    ) -> None:
+    def __init__(self, scope: Construct, stack_id: str, *, deploy_env: str, **kwargs: Any) -> None:
         super().__init__(scope, stack_id, **kwargs)
 
         ############################################################################################

--- a/infrastructure/storage_stack.py
+++ b/infrastructure/storage_stack.py
@@ -4,7 +4,7 @@ Data Lake AWS resources definitions.
 from typing import Any
 
 from aws_cdk import aws_dynamodb, aws_s3, aws_ssm
-from aws_cdk.core import Construct, Stack, Tags
+from aws_cdk.core import Construct, NestedStack, Tags
 
 from backend.datasets_model import DatasetsTitleIdx
 from backend.parameter_store import ParameterName
@@ -15,8 +15,15 @@ from .constructs.table import Table
 from .removal_policy import REMOVAL_POLICY
 
 
-class StorageStack(Stack):
-    def __init__(self, scope: Construct, stack_id: str, *, deploy_env: str, **kwargs: Any) -> None:
+class StorageStack(NestedStack):
+    def __init__(
+        self,
+        scope: Construct,
+        stack_id: str,
+        *,
+        deploy_env: str,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(scope, stack_id, **kwargs)
 
         ############################################################################################


### PR DESCRIPTION
This change should fix our stack updating issues (should not use CF stack exports) and allows us to keep resources logically separated in stacks (with exception of `botocore` stack which is merged with `storage` stack). This change is based on usage of nested stacks and passing resource information between them using CF parameters. 