### PR TITLE
chore: Disable master deploy check

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,9 +7,9 @@ on:
 jobs:
   test-prod-copy-deploy:
     if:
-      github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/heads/release-') ||
-      startsWith(github.ref, 'refs/tags/release-') || github.event.label.name == 'automerge' ||
-      contains(github.event.pull_request.labels.*.name, 'automerge')
+      startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/release-')
+      || github.event.label.name == 'automerge' || contains(github.event.pull_request.labels.*.name,
+      'automerge')
     runs-on: ubuntu-20.04
     strategy:
       matrix:


### PR DESCRIPTION
Should be redundant now that the deploy checks run on automerge labelled
PRs.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
