### PR TITLE
fix: Match automerge label on any event

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deployment
 on:
   push:
   pull_request:
-    types: [labeled]
+    types: [labeled, synchronize]
 
 jobs:
   test-prod-copy-deploy:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,7 +8,7 @@ jobs:
   test-prod-copy-deploy:
     if:
       startsWith(github.ref, 'refs/heads/release-') || startsWith(github.ref, 'refs/tags/release-')
-      || github.event.label.name == 'automerge' || contains(github.event.pull_request.labels.*.name,
+      || github.event.label.name == 'automerge' || contains(github.event.*.labels.*.name,
       'automerge')
     runs-on: ubuntu-20.04
     strategy:


### PR DESCRIPTION
This should ensure that automerge labelled PRs run a deployment check
when pushing to them.

<!-- List of links to issues which will be closed by this PR. Uncomment this section if relevant.
## Issues

Closes https://example.org/issues/1, https://example.org/issues/2.
-->

<!-- List of issues which had to be resolved or worked around to get through this work. Uncomment this section if relevant.
## Challenges

- [X doesn't support Y](https://example.org/issues/1)
-->

## Reference

[Code review checklist](CODING.md#Code-review-checklist)
